### PR TITLE
Add `blogr.route.frontend.enabled` setting

### DIFF
--- a/config/blogr.php
+++ b/config/blogr.php
@@ -4,6 +4,9 @@
 return [
     'posts_per_page' => 10,  // Number of posts per page
     'route' => [
+        'frontend' => [
+            'enabled' => true,
+        ],
         // Prefix for frontend routes, if empty, the blog will be the homepage
         'prefix' => 'blog',
         'middleware' => ['web'], // Middleware for frontend routes

--- a/src/BlogrServiceProvider.php
+++ b/src/BlogrServiceProvider.php
@@ -94,6 +94,32 @@ class BlogrServiceProvider extends PackageServiceProvider
         Testable::mixin(new TestsBlogr);
     }
 
+    protected function registerFrontendRoutes(): void
+    {
+        $prefix = trim(config('blogr.route.prefix', 'blog'), '/');
+
+        if ($prefix === '' || $prefix === '/') {
+            // Blog route as homepage
+            $this->app['router']
+                ->middleware(config('blogr.route.middleware', ['web']))
+                ->group(function () {
+                    $this->app['router']->get('/', [BlogController::class, 'index'])->name('blog.index');
+                    $this->app['router']->get('/{slug}', [BlogController::class, 'show'])->name('blog.show');
+                });
+        } else {
+            // Blog route with prefix
+            $this->app['router']
+                ->prefix($prefix)
+                ->middleware(config('blogr.route.middleware', ['web']))
+                ->group(function () {
+                    $this->app['router']->get('/', [BlogController::class, 'index'])->name('blog.index');
+                    $this->app['router']->get('/{slug}', [BlogController::class, 'show'])->name('blog.show');
+                    $this->app['router']->get('/category/{categorySlug}', [BlogController::class, 'category'])->name('blog.category');
+                    $this->app['router']->get('/tag/{tagSlug}', [BlogController::class, 'tag'])->name('blog.tag');
+                });
+        }
+    }
+
     /**
      * Register the blog widgets
      */
@@ -219,25 +245,8 @@ class BlogrServiceProvider extends PackageServiceProvider
 
         $prefix = trim(config('blogr.route.prefix', 'blog'), '/');
 
-        if ($prefix === '' || $prefix === '/') {
-            // Blog route as homepage
-            $this->app['router']
-                ->middleware(config('blogr.route.middleware', ['web']))
-                ->group(function () {
-                    $this->app['router']->get('/', [BlogController::class, 'index'])->name('blog.index');
-                    $this->app['router']->get('/{slug}', [BlogController::class, 'show'])->name('blog.show');
-                });
-        } else {
-            // Blog route with prefix
-            $this->app['router']
-                ->prefix($prefix)
-                ->middleware(config('blogr.route.middleware', ['web']))
-                ->group(function () {
-                    $this->app['router']->get('/', [BlogController::class, 'index'])->name('blog.index');
-                    $this->app['router']->get('/{slug}', [BlogController::class, 'show'])->name('blog.show');
-                    $this->app['router']->get('/category/{categorySlug}', [BlogController::class, 'category'])->name('blog.category');
-                    $this->app['router']->get('/tag/{tagSlug}', [BlogController::class, 'tag'])->name('blog.tag');
-                });
+        if (config()->get('blogr.route.frontend.enabled', true)) {
+            $this->registerFrontendRoutes();
         }
     }
 }

--- a/src/Filament/Pages/BlogrSettings.php
+++ b/src/Filament/Pages/BlogrSettings.php
@@ -32,9 +32,7 @@ class BlogrSettings extends Page
     // Form properties
     public ?int $posts_per_page = null;
     public ?string $route_prefix = null;
-
     public ?bool $route_frontend_enabled = null;
-
     public ?string $colors_primary = null;
     public ?string $blog_index_cards_colors_background = null;
     public ?string $blog_index_cards_colors_top_border = null;

--- a/src/Filament/Pages/BlogrSettings.php
+++ b/src/Filament/Pages/BlogrSettings.php
@@ -32,6 +32,9 @@ class BlogrSettings extends Page
     // Form properties
     public ?int $posts_per_page = null;
     public ?string $route_prefix = null;
+
+    public ?bool $route_frontend_enabled = null;
+
     public ?string $colors_primary = null;
     public ?string $blog_index_cards_colors_background = null;
     public ?string $blog_index_cards_colors_top_border = null;
@@ -61,6 +64,7 @@ class BlogrSettings extends Page
         // Set form properties from config
         $this->posts_per_page = $config['posts_per_page'] ?? 10;
         $this->route_prefix = $config['route']['prefix'] ?? 'blog';
+        $this->route_frontend_enabled = $config['route']['frontend']['enabled'] ?? true;
         $this->colors_primary = $config['colors']['primary'] ?? '#3b82f6';
         $this->blog_index_cards_colors_background = $config['blog_index']['cards']['colors']['background'] ?? 'bg-white';
         $this->blog_index_cards_colors_top_border = $config['blog_index']['cards']['colors']['top_border'] ?? 'border-t-4 border-blue-500';
@@ -100,6 +104,11 @@ class BlogrSettings extends Page
                             ->label('Route Prefix')
                             ->placeholder('blog')
                             ->helperText('URL prefix for blog routes')
+                            ->required(),
+                        Toggle::make('route_frontend_enabled')
+                            ->label('Enable Frontend Routes')
+                            ->helperText('Enable frontend routes for the blog')
+                            ->default(true)
                             ->required(),
                     ])
                     ->columns(2),
@@ -211,6 +220,9 @@ class BlogrSettings extends Page
             'posts_per_page' => $this->posts_per_page,
             'route' => [
                 'prefix' => $this->route_prefix,
+                'frontend' => [
+                    'enabled' => $this->route_frontend_enabled,
+                ],
             ],
             'colors' => [
                 'primary' => $this->colors_primary,

--- a/tests/Feature/BlogrSettingsFilamentIntegrationTest.php
+++ b/tests/Feature/BlogrSettingsFilamentIntegrationTest.php
@@ -23,6 +23,7 @@ it('blogr settings has all required public properties', function () {
     $expectedProperties = [
         'posts_per_page',
         'route_prefix',
+        'route_frontend_enabled',
         'reading_speed_words_per_minute',
         'reading_time_text_format',
         'reading_time_enabled',
@@ -47,6 +48,7 @@ it('blogr settings mount method loads config correctly', function () {
     config([
         'blogr.posts_per_page' => 25,
         'blogr.route.prefix' => 'articles',
+        'blogr.route.frontend.enabled' => true,
         'blogr.reading_time.enabled' => false,
         'blogr.seo.site_name' => 'Test Blog',
         'blogr.seo.structured_data.enabled' => false,
@@ -58,6 +60,7 @@ it('blogr settings mount method loads config correctly', function () {
     // Test that config values are loaded into properties
     expect($page->posts_per_page)->toBe(25);
     expect($page->route_prefix)->toBe('articles');
+    expect($page->route_frontend_enabled)->toBeTrue();
     expect($page->reading_time_enabled)->toBeFalse();
     expect($page->seo_site_name)->toBe('Test Blog');
     expect($page->seo_structured_data_enabled)->toBeFalse();

--- a/tests/Feature/routes.php
+++ b/tests/Feature/routes.php
@@ -3,9 +3,11 @@
 use Happytodev\Blogr\Http\Controllers\BlogController;
 use Illuminate\Support\Facades\Route;
 
-// Blog routes for testing
-Route::get('/blog', [BlogController::class, 'index'])->name('blog.index');
-Route::get('/blog/{slug}', [BlogController::class, 'show'])->name('blog.show');
+if (config('blogr.route.frontend.enabled', true)) {
+    // Blog routes for testing
+    Route::get('/blog', [BlogController::class, 'index'])->name('blog.index');
+    Route::get('/blog/{slug}', [BlogController::class, 'show'])->name('blog.show');
+}
 
 // Filament routes for browser testing
 Route::middleware('web')->group(function () {

--- a/workbench/config/blogr.php
+++ b/workbench/config/blogr.php
@@ -4,6 +4,9 @@
 return [
     'posts_per_page' => 10,  // Number of posts per page
     'route' => [
+        'frontend' => [
+            'enabled' => true,
+        ],
         // Prefix for frontend routes, if empty, the blog will be the homepage
         'prefix' => 'blog',
         'middleware' => ['web'], // Middleware for frontend routes


### PR DESCRIPTION
# Problem 

I want to be able to disable the frontend routing system entirely and generate my own blog display pages.

# Proposed solution

I've added a setting to the config file that enables/disables this.  I've also defaulted the setting in the code to `enabled` so it is backward compatible and anyone without the setting will not see a change.

# Notes - important

I was able to do some cursory checks that seem to indicate that my changes work but due to how PestPHP works and how it doesn't run until after the Laravel application has already been booted - and therefore, crucially, the routes *already having been registered* - I could not find any way (elegant or otherwise) to programmatically adjust this setting to confirm that it doesn't break things.  

I also tried writing an individual `TestCaseWithFrontendRoutesDisabled::class` but again, PestPHP will *only* allow you to register one test case per file or folder, and since we want the default `TestCase::class` to be registered for the entire `tests/` folder recursively, I wasn't sure how to apply our specialized test case just to one test file.

If you have any suggestions of ways I could go about testing this, I'd be happy to apply them and write a positive and negative test case, confirming what we're trying to do here.

All that said, I *did* update the Filament testing since that part was relatively easy.