### PR TITLE
feat: add video embed support in blog posts and CMS pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to `blogr` will be documented in this file.
 
 ## Unpublished
 
+## [v0.17.0](https://github.com/happytodev/blogr/compare/v0.17.0...v0.16.0) - 2026-03-09
+
+### ✨ Features
+
+- **Video Embed Integration in Blog Posts and CMS Pages**:
+  - Standalone video URLs placed on their own line in Markdown content are automatically converted to responsive embedded players — no shortcode or extra syntax needed
+  - **Supported Providers**:
+    - **YouTube**: `youtube.com/watch?v=ID` and short `youtu.be/ID` URLs (served via `youtube-nocookie.com` for enhanced privacy)
+    - **Vimeo**: `vimeo.com/ID`
+    - **Dailymotion**: `dailymotion.com/video/ID`
+  - **Implementation**: Uses the built-in `league/commonmark` `EmbedExtension` with a custom `VideoEmbedAdapter` — zero new dependencies required
+  - **Scope**: Works in all Markdown-rendered areas:
+    - Blog post content (with TOC support)
+    - CMS page content blocks
+    - FAQ page content
+  - **Responsive output**: Embeds render inside a 16/9 `aspect-video` wrapper with Tailwind classes (`rounded-xl`, `shadow-lg`)
+  - **Security**: URLs are escaped with `htmlspecialchars()` before being placed in `src` attributes; inline URLs in paragraphs are never converted
+  - **Test Coverage**: 8 tests (17 assertions) in `tests/Unit/VideoEmbedAdapterTest.php`
+  - **Files Added/Modified**:
+    - `src/Extensions/VideoEmbedAdapter.php` (new)
+    - `src/Helpers/MarkdownHelper.php` (EmbedExtension added)
+    - `src/Http/Controllers/BlogController.php` (EmbedExtension added to converter)
+    - `tests/Unit/VideoEmbedAdapterTest.php` (new)
+
 ## [v0.16.0](https://github.com/happytodev/blogr/compare/v0.16.0...v0.15.12) - 2026-01-29
 
 ### ✨ Features

--- a/src/Extensions/VideoEmbedAdapter.php
+++ b/src/Extensions/VideoEmbedAdapter.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Happytodev\Blogr\Extensions;
+
+use League\CommonMark\Extension\Embed\Embed;
+use League\CommonMark\Extension\Embed\EmbedAdapterInterface;
+
+/**
+ * Transforms standalone video URLs into responsive embed iframes.
+ * Supports YouTube, Vimeo and Dailymotion without external dependencies.
+ */
+class VideoEmbedAdapter implements EmbedAdapterInterface
+{
+    public function updateEmbeds(array $embeds): void
+    {
+        foreach ($embeds as $embed) {
+            $code = $this->resolveEmbedCode($embed->getUrl());
+            if ($code !== null) {
+                $embed->setEmbedCode($code);
+            }
+        }
+    }
+
+    private function resolveEmbedCode(string $url): ?string
+    {
+        // YouTube: youtube.com/watch?v=ID or youtu.be/ID
+        if (preg_match(
+            '/(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/',
+            $url,
+            $matches
+        )) {
+            return $this->buildIframe(
+                'https://www.youtube-nocookie.com/embed/' . $matches[1],
+                'allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen'
+            );
+        }
+
+        // Vimeo: vimeo.com/ID
+        if (preg_match('/vimeo\.com\/(\d+)/', $url, $matches)) {
+            return $this->buildIframe(
+                'https://player.vimeo.com/video/' . $matches[1],
+                'allow="autoplay; fullscreen; picture-in-picture" allowfullscreen'
+            );
+        }
+
+        // Dailymotion: dailymotion.com/video/ID
+        if (preg_match('/dailymotion\.com\/video\/([a-zA-Z0-9]+)/', $url, $matches)) {
+            return $this->buildIframe(
+                'https://www.dailymotion.com/embed/video/' . $matches[1],
+                'allow="autoplay; fullscreen; picture-in-picture" allowfullscreen'
+            );
+        }
+
+        return null;
+    }
+
+    private function buildIframe(string $src, string $extraAttributes): string
+    {
+        return sprintf(
+            '<div class="video-embed aspect-video w-full rounded-xl overflow-hidden shadow-lg my-8">'
+            . '<iframe src="%s" class="w-full h-full" frameborder="0" %s></iframe>'
+            . '</div>',
+            htmlspecialchars($src, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            $extraAttributes
+        );
+    }
+}

--- a/src/Helpers/MarkdownHelper.php
+++ b/src/Helpers/MarkdownHelper.php
@@ -2,8 +2,10 @@
 
 namespace Happytodev\Blogr\Helpers;
 
+use Happytodev\Blogr\Extensions\VideoEmbedAdapter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\Embed\EmbedExtension;
 use League\CommonMark\MarkdownConverter;
 
 class MarkdownHelper
@@ -19,13 +21,19 @@ class MarkdownHelper
             $environment = new Environment([
                 'html_input' => 'escape',  // Escape HTML to prevent XSS
                 'allow_unsafe_links' => false,
+                'embed' => [
+                    'adapter' => new VideoEmbedAdapter(),
+                    'allowed_domains' => [],
+                    'fallback' => 'link',
+                ],
             ]);
-            
+
             $environment->addExtension(new CommonMarkCoreExtension());
-            
+            $environment->addExtension(new EmbedExtension());
+
             static::$converter = new MarkdownConverter($environment);
         }
-        
+
         return static::$converter;
     }
 

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -13,10 +13,12 @@ use Happytodev\Blogr\Models\BlogPostTranslation;
 use Happytodev\Blogr\Models\BlogSeries;
 use Happytodev\Blogr\Models\Category;
 use Illuminate\Support\Facades\Storage;
+use Happytodev\Blogr\Extensions\VideoEmbedAdapter;
 use League\CommonMark\MarkdownConverter;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\Embed\EmbedExtension;
 use League\CommonMark\Extension\TableOfContents\TableOfContentsExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 
@@ -268,11 +270,17 @@ class BlogController
                 'normalize' => 'relative',
                 'html_class' => $tocHtmlClass,
             ],
+            'embed' => [
+                'adapter' => new VideoEmbedAdapter(),
+                'allowed_domains' => [],
+                'fallback' => 'link',
+            ],
         ]);
 
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new HeadingPermalinkExtension());
         $environment->addExtension(new TableOfContentsExtension());
+        $environment->addExtension(new EmbedExtension());
 
         $converter = new MarkdownConverter($environment);
 

--- a/tests/Unit/VideoEmbedAdapterTest.php
+++ b/tests/Unit/VideoEmbedAdapterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Happytodev\Blogr\Extensions\VideoEmbedAdapter;
+use Happytodev\Blogr\Helpers\MarkdownHelper;
+use League\CommonMark\Extension\Embed\Embed;
+
+// ─── VideoEmbedAdapter unit tests ────────────────────────────────────────────
+
+it('generates a YouTube embed from a standard watch URL', function () {
+    $adapter = new VideoEmbedAdapter();
+    $embed = new Embed('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+
+    $adapter->updateEmbeds([$embed]);
+
+    expect($embed->getEmbedCode())
+        ->toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ')
+        ->toContain('<iframe')
+        ->toContain('allowfullscreen')
+        ->toContain('aspect-video');
+});
+
+it('generates a YouTube embed from a short youtu.be URL', function () {
+    $adapter = new VideoEmbedAdapter();
+    $embed = new Embed('https://youtu.be/dQw4w9WgXcQ');
+
+    $adapter->updateEmbeds([$embed]);
+
+    expect($embed->getEmbedCode())
+        ->toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ');
+});
+
+it('generates a Vimeo embed', function () {
+    $adapter = new VideoEmbedAdapter();
+    $embed = new Embed('https://vimeo.com/123456789');
+
+    $adapter->updateEmbeds([$embed]);
+
+    expect($embed->getEmbedCode())
+        ->toContain('player.vimeo.com/video/123456789')
+        ->toContain('<iframe')
+        ->toContain('allowfullscreen');
+});
+
+it('generates a Dailymotion embed', function () {
+    $adapter = new VideoEmbedAdapter();
+    $embed = new Embed('https://www.dailymotion.com/video/x7tgd2g');
+
+    $adapter->updateEmbeds([$embed]);
+
+    expect($embed->getEmbedCode())
+        ->toContain('dailymotion.com/embed/video/x7tgd2g')
+        ->toContain('<iframe');
+});
+
+it('does not set embed code for non-video URLs', function () {
+    $adapter = new VideoEmbedAdapter();
+    $embed = new Embed('https://example.com/some-page');
+
+    $adapter->updateEmbeds([$embed]);
+
+    expect($embed->getEmbedCode())->toBeNull();
+});
+
+// ─── MarkdownHelper integration ──────────────────────────────────────────────
+
+it('converts a standalone YouTube URL in markdown to an iframe embed', function () {
+    $markdown = "Some text before\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ\n\nSome text after";
+
+    $html = MarkdownHelper::toHtml($markdown);
+
+    expect($html)
+        ->toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ')
+        ->toContain('<iframe')
+        ->toContain('aspect-video');
+});
+
+it('converts a standalone Vimeo URL in markdown to an iframe embed', function () {
+    $markdown = "https://vimeo.com/123456789";
+
+    $html = MarkdownHelper::toHtml($markdown);
+
+    expect($html)
+        ->toContain('player.vimeo.com/video/123456789')
+        ->toContain('<iframe');
+});
+
+it('does not convert a YouTube URL that is inline in a paragraph', function () {
+    // URL is not alone on its own line – should remain as text/link, not embed
+    $markdown = "Check out this video: https://www.youtube.com/watch?v=dQw4w9WgXcQ and more text.";
+
+    $html = MarkdownHelper::toHtml($markdown);
+
+    expect($html)->not->toContain('<iframe');
+});


### PR DESCRIPTION
- Add VideoEmbedAdapter supporting YouTube, Vimeo and Dailymotion
- Integrate EmbedExtension in MarkdownHelper and BlogController
- YouTube URLs use youtube-nocookie.com for privacy
- 8 unit tests (17 assertions) in VideoEmbedAdapterTest
- Responsive 16/9 aspect-video wrapper with Tailwind classes
- No new dependencies (uses built-in league/commonmark EmbedExtension)