### PR TITLE
chore: ignore PHPStan cache and unrelated markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,7 @@ vendor
 *.code-workspace
 tests/Browser/Screenshots
 storage/app/blogr-exports/blogr-homepage-v*.json
+storage/framework/
+post-mortem-*.md
+weekly-update-*.md
 


### PR DESCRIPTION
## Summary\n\n- Added storage/framework/ to .gitignore (PHPStan cache, 3041 files)\n- Added post-mortem-*.md and weekly-update-*.md patterns\n- Reduces VS Code Source Control noise from 3043 to 0