### PR TITLE
skill(release): add merge step, pre-flight check, and workflow docs

### DIFF
--- a/.opencode/skills/git-changelog-workflow/SKILL.md
+++ b/.opencode/skills/git-changelog-workflow/SKILL.md
@@ -269,6 +269,25 @@ Return the URL of the created PR or the "New Pull Request" link.
 
 ---
 
+## Step 6 — Merge the Pull Request (optional)
+
+After the PR is created, propose to merge it immediately:
+
+```bash
+gh pr merge $PR_NUMBER --squash --subject "type(scope): summary"
+```
+
+If `gh` is not available, provide the GitHub merge URL:
+`https://github.com/happytodev/blogr/pull/$PR_NUMBER`
+
+This step is **optional** — PRs can also be merged later as part of a
+release batch (see `release-manager`). If the user plans to accumulate
+multiple PRs before releasing, skip this step.
+
+**Do not merge without explicit user validation.**
+
+---
+
 ## Git authentication
 
 If `git push` fails with `HTTP Basic: Access denied`:

--- a/.opencode/skills/release-manager/SKILL.md
+++ b/.opencode/skills/release-manager/SKILL.md
@@ -9,6 +9,38 @@ Trigger phrases: "release", "tag a new version", "publish vX.Y.Z", "cut a releas
 
 ## Workflow
 
+### 0. Pre-flight check — all PRs must be merged
+
+Before any release work, verify that no open PRs target `main`:
+
+```bash
+git fetch origin main
+OPEN_PRS=$(gh pr list --base main --state open --json number,title --jq '.[] | "\(.number) \(.title)"')
+```
+
+If `$OPEN_PRS` is not empty, **abort immediately** and display:
+
+```markdown
+## ⛔ Release blocked — open PRs detected
+
+The following PRs must be merged into `main` before releasing:
+
+| # | Title |
+|---|-------|
+| 12 | feat: ... |
+| 14 | fix: ... |
+
+Options:
+1. Merge them now (`gh pr merge <number> --squash`)
+2. Cancel the release and come back later
+```
+
+**Do not proceed** until all open PRs targeting `main` are merged.
+This ensures the release captures the intended changes and avoids
+accidental version bumps with unmerged work.
+
+---
+
 ### 1. Preview changes since the last release
 
 - Run: `git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-decorate`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,41 @@ The built CSS (`resources/dist/blogr.css`) MUST be committed alongside view chan
 - **Project quality**: After each sprint, improve the quality harness via [harness-evolution](.opencode/skills/harness-evolution/SKILL.md) (tests, PHPStan, lint JS, coverage, CI, hooks).
 - **Dependencies**: For safe updates with security guardrails, use [safe-dependency-update](.opencode/skills/safe-dependency-update/SKILL.md) (72h filter, patch/minor/major, human validation).
 
+## Workflow cycle — feature/bug to release
+
+```
+User command              Skill              Action
+─────────────────────────────────────────────────────────────────────
+"fix this bug"        →  issue-to-mr        Issue → analysis → TDD
+"commit changes"      →  git-changelog      Batch analysis → branch
+                                            → CHANGELOG → commits
+                                            → PR → [optional merge]
+"release"             →  release-manager    Pre-flight (all PRs merged?)
+                                            → version bump → tag
+                                            → GitHub Release
+```
+
+### Step-by-step user commands
+
+| Phase | User says | What happens |
+|-------|-----------|-------------|
+| **Bug / feature** | `"there is a bug: …"` or `"I need a feature: …"` | `issue-to-mr` loads: creates GitHub issue, analyzes code, develops fix/feature with TDD, calls `git-changelog-workflow` |
+| **Commit** | `"commit changes"` | `git-changelog-workflow` loads: batch analysis (group or split), branch from `main`, CHANGELOG proposal, atomic commits, PR creation, optional merge |
+| **Merge** | `"merge the PR"` (optional) | `git-changelog-workflow` step 6: `gh pr merge --squash` |
+| **Release** | `"release"` or `"cut a release"` or `"tag vX.Y.Z"` | `release-manager` loads: pre-flight check (all PRs merged?), version bump, CHANGELOG, tag, GitHub Release |
+
+### Merge strategies
+
+- **Merge immediately**: After `git-changelog-workflow` creates the PR, say **"merge the PR"**. The PR is squash-merged and `main` is updated.
+- **Batch before release**: Skip merge, accumulate multiple PRs, then say **"release"**. The `release-manager` will list all open PRs and ask you to merge them before proceeding.
+- **Hybrid**: Merge some PRs immediately, let others wait. The `release-manager` pre-flight check only blocks if unmerged PRs exist.
+
+### Pre-flight gate
+
+The `release-manager` will **not** cut a release while PRs are still open
+against `main`. This prevents accidental releases with unmerged work.
+Always merge all intended PRs before running `release`.
+
 ## CI
 
 - Runs on `ubuntu-latest`, PHP 8.4, Laravel 12.*, `prefer-stable`.


### PR DESCRIPTION
## Summary

Closes the workflow loop from feature/bug to release:
- **git-changelog-workflow**: optional merge step after PR creation
- **release-manager**: pre-flight check that blocks release if PRs are still open
- **AGENTS.md**: full workflow table with user commands and merge strategies

## Test plan
- [ ] `vendor/bin/pest --parallel` → passes