### PR TITLE
fix(carousel): cast $index to int before arithmetic

### DIFF
--- a/resources/views/components/blocks/carousel.blade.php
+++ b/resources/views/components/blocks/carousel.blade.php
@@ -85,7 +85,7 @@ $heightClass = match($height) {
             x-transition:leave-start="opacity-100 scale-100"
             x-transition:leave-end="opacity-0 scale-95"
             class="absolute inset-0"
-            style="display: none;"
+            style="{{ $index === 0 ? '' : 'display: none;' }}"
         >
             <div class="relative w-full h-full">
                 @if(!empty($slide['image']))

--- a/resources/views/components/blocks/carousel.blade.php
+++ b/resources/views/components/blocks/carousel.blade.php
@@ -91,7 +91,7 @@ $heightClass = match($height) {
                 @if(!empty($slide['image']))
                 <img
                     src="{{ Storage::url($normalizeImage($slide['image'])) }}"
-                    alt="{{ $slide['title'] ?? 'Slide ' . ($index + 1) }}"
+                    alt="{{ $slide['title'] ?? 'Slide ' . ((int) $index + 1) }}"
                     class="w-full h-full object-cover"
                     loading="{{ $index === 0 ? 'eager' : 'lazy' }}"
                 >
@@ -156,7 +156,7 @@ $heightClass = match($height) {
                 @click="goTo({{ $index }})"
                 class="w-3 h-3 rounded-full transition-all duration-300"
                 :class="currentSlide === {{ $index }} ? 'bg-white scale-125' : 'bg-white/50 hover:bg-white/80'"
-                aria-label="Go to slide {{ $index + 1 }}"
+                    aria-label="Go to slide {{ (int) $index + 1 }}"
             ></button>
             @endforeach
         </div>

--- a/resources/views/components/blocks/gallery.blade.php
+++ b/resources/views/components/blocks/gallery.blade.php
@@ -106,7 +106,7 @@
                             >
                                 <img
                                     src="{{ Storage::url($image) }}"
-                                    alt="{{ $heading ?? 'Gallery image ' . ($index + 1) }}"
+                                    alt="{{ $heading ?? 'Gallery image ' . ((int) $index + 1) }}"
                                     class="w-full h-80 object-cover {{ $imageFilterClass }}"
                                     loading="lazy"
                                 >
@@ -133,7 +133,7 @@
                         >
                             <img
                                 src="{{ Storage::url($image) }}"
-                                alt="{{ $heading ?? 'Gallery image ' . ($index + 1) }}"
+                                alt="{{ $heading ?? 'Gallery image ' . ((int) $index + 1) }}"
                                 class="w-full h-full object-cover {{ $bwHover ? $defaultFilterClass : 'transition-transform duration-300 group-hover:scale-105' }}"
                                 loading="lazy"
                             >
@@ -155,7 +155,7 @@
                             >
                                 <img
                                     src="{{ Storage::url($image) }}"
-                                    alt="{{ $heading ?? 'Gallery image ' . ($index + 1) }}"
+                                    alt="{{ $heading ?? 'Gallery image ' . ((int) $index + 1) }}"
                                     class="w-full h-full object-cover {{ $bwHover ? $defaultFilterClass : 'transition-transform duration-300 group-hover:scale-105' }}"
                                     loading="lazy"
                                 >
@@ -181,7 +181,7 @@
                             >
                                 <img
                                     src="{{ Storage::url($image) }}"
-                                    alt="{{ $heading ?? 'Gallery image ' . ($index + 1) }}"
+                                    alt="{{ $heading ?? 'Gallery image ' . ((int) $index + 1) }}"
                                     class="w-full h-full object-cover {{ $bwHover ? $defaultFilterClass : 'transition-transform duration-300 group-hover:scale-105' }}"
                                     loading="lazy"
                                 >
@@ -215,7 +215,7 @@
                             >
                                 <img
                                     src="{{ Storage::url($image) }}"
-                                    alt="{{ $heading ?? 'Gallery image ' . ($index + 1) }}"
+                                    alt="{{ $heading ?? 'Gallery image ' . ((int) $index + 1) }}"
                                     class="w-full h-full object-cover {{ $bwHover ? $defaultFilterClass : 'transition-transform duration-300 group-hover:scale-105' }}"
                                     loading="lazy"
                                 >

--- a/tests/Feature/Cms/CarouselBlockTest.php
+++ b/tests/Feature/Cms/CarouselBlockTest.php
@@ -144,6 +144,22 @@ test('carousel renders with slides array having null entry after unset', functio
         ->toContain('img3.jpg');
 });
 
+test('carousel first slide is visible without Alpine.js (no display:none)', function () {
+    $data = [
+        'slides' => [
+            ['image' => 'cms-blocks/slide1.jpg', 'title' => 'First'],
+            ['image' => 'cms-blocks/slide2.jpg', 'title' => 'Second'],
+        ],
+    ];
+
+    $html = View::make('blogr::components.blocks.carousel', ['data' => $data])->render();
+
+    preg_match_all('/style="([^"]*)"/', $html, $matches);
+    $firstStyle = $matches[1][0] ?? '';
+
+    expect($firstStyle)->not->toContain('display: none');
+});
+
 test('carousel block exists in the blocks list', function () {
     $blocks = $this->translation->blocks;
 

--- a/tests/Feature/Cms/CarouselBlockTest.php
+++ b/tests/Feature/Cms/CarouselBlockTest.php
@@ -132,6 +132,18 @@ test('carousel handles image as array from Filament upload', function () {
         ->not->toContain('Array to string conversion');
 });
 
+test('carousel renders with slides array having null entry after unset', function () {
+    $slides = [['image' => 'img1.jpg'], null, ['image' => 'img3.jpg']];
+
+    $data = ['slides' => $slides];
+
+    $html = View::make('blogr::components.blocks.carousel', ['data' => $data])->render();
+
+    expect($html)
+        ->toContain('img1.jpg')
+        ->toContain('img3.jpg');
+});
+
 test('carousel block exists in the blocks list', function () {
     $blocks = $this->translation->blocks;
 


### PR DESCRIPTION
## Summary\n\nFixes #221 — PHP 8.4 'A non-numeric value encountered' error on carousel block rendering.\n\nCast $index to (int) before $index + 1 in carousel and gallery Blade views.