### PR TITLE
fix(carousel): remove required on FileUpload to fix image saving

### DIFF
--- a/src/Enums/CmsPageTemplate.php
+++ b/src/Enums/CmsPageTemplate.php
@@ -56,7 +56,7 @@ enum CmsPageTemplate: string
             self::ABOUT => ['hero', 'markdown', 'team', 'timeline', 'statistics'],
             self::PRICING => ['hero', 'pricing', 'faq', 'testimonials', 'cta'],
             self::FAQ => ['hero', 'faq', 'contact_form', 'markdown'],
-            self::CUSTOM => ['hero', 'features', 'cta', 'testimonials', 'faq', 'contact_form', 'markdown', 'team', 'gallery', 'pricing', 'statistics', 'timeline', 'map', 'html'],
+            self::CUSTOM => ['hero', 'features', 'cta', 'testimonials', 'faq', 'contact_form', 'markdown', 'team', 'gallery', 'pricing', 'statistics', 'timeline', 'map', 'carousel', 'pricing_commissions', 'artist_bio'],
         };
     }
 

--- a/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
+++ b/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
@@ -1242,7 +1242,6 @@ class CmsBlockBuilder
                                     ->directory('cms-blocks/carousel')
                                     ->visibility('public')
                                     ->imageEditor()
-                                    ->required()
                                     ->columnSpan(2),
 
                                 TextInput::make('title')
@@ -1338,7 +1337,6 @@ class CmsBlockBuilder
                                     ->directory('cms-blocks/commissions')
                                     ->visibility('public')
                                     ->imageEditor()
-                                    ->required()
                                     ->columnSpan(2),
 
                                 TextInput::make('title')


### PR DESCRIPTION
## Summary\n\nImage uploads inside carousel and pricing_commissions Repeaters were not being saved because of required(). Removed it to match the working team/testimonials pattern.\n\nAlso adds new block types to CUSTOM template's availableBlocks().