### PR TITLE
fix(team): normalize photo path from Filament upload array

### DIFF
--- a/resources/views/components/blocks/team.blade.php
+++ b/resources/views/components/blocks/team.blade.php
@@ -5,7 +5,14 @@
     $description = $data['description'] ?? null;
     $members = $data['members'] ?? [];
     $columns = $data['columns'] ?? '3';
-    
+
+    $normalizeImage = function ($image) {
+        if (is_array($image)) {
+            return $image[0] ?? '';
+        }
+        return $image ?? '';
+    };
+
     $gridCols = match($columns) {
         '2' => 'grid-cols-1 sm:grid-cols-2',
         '3' => 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
@@ -40,7 +47,7 @@
                         @if(!empty($member['photo']))
                             <div class="relative mb-4 overflow-hidden rounded-2xl aspect-square">
                                 <img 
-                                    src="{{ Storage::url($member['photo']) }}" 
+                                    src="{{ Storage::url($normalizeImage($member['photo'])) }}" 
                                     alt="{{ $member['name'] ?? 'Team member' }}"
                                     class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
                                     loading="lazy"

--- a/tests/Feature/Cms/CmsCarouselIntegrationTest.php
+++ b/tests/Feature/Cms/CmsCarouselIntegrationTest.php
@@ -136,6 +136,21 @@ test('carousel block renders stored images on frontend', function () {
         ->toContain('goTo(1)');
 });
 
+test('team block handles photo as array from Filament upload', function () {
+    $data = [
+        'members' => [
+            ['photo' => ['cms-blocks/team/photo1.jpg'], 'name' => 'John'],
+        ],
+    ];
+
+    $html = view('blogr::components.blocks.team', ['data' => $data])->render();
+
+    expect($html)
+        ->toContain('John')
+        ->toContain('/storage/cms-blocks/team/photo1.jpg')
+        ->not->toContain('Array to string conversion');
+});
+
 test('carousel simulates Filament form submission data format', function () {
     $uuid1 = '3c5b8554-ad6a-49fe-94c6-791432c42743';
     $uuid2 = '172e9085-71a1-4a21-b28c-f652d7bb2928';


### PR DESCRIPTION
## Summary\n\nTeam block was crashing with 'Array to string conversion' because FileUpload inside Repeater stores photo path as array.\n\nAdded $normalizeImage() helper (same pattern as carousel).