### PR TITLE
feat(plugins): plugin system overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **Plugins**: add `getSettingsUrl()` and `registerExtension()` to `BlogrExtension` interface (replaces `register()` — renamed to avoid `FilamentPlugin` collision)
+- **Plugins**: add settings gear icon ⚙️ on each plugin card, linked to `getSettingsUrl()` when defined
+- **Plugins**: add Community Plugins discovery section — parses `README.md` plugins table with GitHub/GitLab links
+- **Plugins**: filter out already-installed plugins from community listing by repo name or homepage URL
+- **Plugins**: add "Develop a Plugin" section with link to developing guide
+- **Docs**: add `## Developing Plugins` section to README with interface reference, registration, and lifecycle
+
+### 🐛 Fixed
+
+- **Plugins**: fix enable/disable toggles having no effect — `register(Panel)` now queries `blogr_extension_states` directly (bypasses singleton timing issue)
+- **Plugins**: fix `RouteNotFoundException` when toggling a plugin on — `getSettingsUrl()` catches missing routes gracefully
+- **Plugins**: fix `loadedFromDb` flag in `ExtensionRegistry::loadStatesIfNeeded()` being set before DB query
+- **Plugins**: prevent auto-resolution of throwaway `ExtensionRegistry` instance when called before singleton registration
+- **Artist/Comms/GDPR**: add `shouldRegisterNavigation()` to settings pages — navigation respects enable/disable state
+- **Artist/Comms/GDPR**: move `$panel->plugin()` registration to `register()` phase so routes exist before navigation rendering
+
 ## [v1.19.0](https://github.com/happytodev/blogr/compare/v1.18.1...v1.19.0) - 2026-06-29
 
 ### ✨ Features

--- a/README.md
+++ b/README.md
@@ -435,17 +435,74 @@ After installation:
 
 ---
 
-## 🔒 GDPR Plugin
+## Plugins
 
-Add full GDPR compliance to your Blogr site with the official [Blogr GDPR](https://github.com/happytodev/blogr-gdpr) plugin:
+| Plugin | Description | Repository |
+|--------|-------------|------------|
+| GDPR | Cookie consent, privacy policy, data export & erasure | [happytodev/blogr-gdpr](https://github.com/happytodev/blogr-gdpr) |
+| Comments | Threaded comments with moderation, voting, anti-spam, and email notifications | [happytodev/blogr-comments](https://github.com/happytodev/blogr-comments) |
+| Artist Portfolio | Artist portfolio with artwork management, portfolio pages, and commission showcase | [happytodev/blogr-artist](https://github.com/happytodev/blogr-artist) |
 
-[![blogr-gdpr](https://img.shields.io/packagist/v/happytodev/blogr-gdpr.svg?style=flat-square&label=blogr-gdpr)](https://packagist.org/packages/happytodev/blogr-gdpr) [![GDPR Tests](https://img.shields.io/github/actions/workflow/status/happytodev/blogr-gdpr/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/happytodev/blogr-gdpr/actions)
+---
 
-Cookie consent, privacy policy, data export & erasure — install in one command:
+## Developing Plugins
 
-```bash
-composer require happytodev/blogr-gdpr
+Blogr plugins are Composer packages that implement the `Happytodev\Blogr\Contracts\BlogrExtension` interface.
+
+### Quick start
+
+Create a new package and implement the interface:
+
+```php
+use Happytodev\Blogr\Contracts\BlogrExtension;
+use Happytodev\Blogr\Services\ExtensionRegistry;
+use Happytodev\Blogr\Services\LinkTypeRegistry;
+
+class MyPlugin implements BlogrExtension
+{
+    public function getId(): string { return 'my-plugin'; }
+    public function getName(): string { return 'My Plugin'; }
+    public function getDescription(): string { return 'What it does.'; }
+    public function getVersion(): string { return '1.0.0'; }
+    public function getAuthor(): string { return 'Your Name'; }
+    public function getHomepage(): ?string { return 'https://github.com/you/my-plugin'; }
+    public function getDependencies(): array { return ['blogr-core']; }
+    public function getSettingsUrl(): ?string { return null; }
+    public function registerExtension(ExtensionRegistry $registry): void {}
+    public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+}
 ```
+
+### Registration
+
+In your package's service provider, register the extension:
+
+```php
+public function packageBooted(): void
+{
+    if ($this->app->has(\Happytodev\Blogr\Services\ExtensionRegistry::class)) {
+        $this->app->make(\Happytodev\Blogr\Services\ExtensionRegistry::class)
+            ->register(new MyPlugin);
+    }
+}
+```
+
+The extension then appears in the **Plugins** admin page where users can enable/disable it.
+
+### Linking to settings
+
+If your plugin has a Filament settings page, return its URL from `getSettingsUrl()` — a ⚙️ icon will appear next to the plugin toggle:
+
+```php
+public function getSettingsUrl(): ?string
+{
+    return MySettings::getUrl();
+}
+```
+
+### Lifecycle
+
+When the extension is enabled, `registerExtension()` is called during the application boot cycle. Use it to register routes, Livewire components, or other features conditionally.
 
 ---
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,5 +3,9 @@ pre-commit:
     commands:
         pint:
             run: vendor/bin/pint --test
+            env:
+                PATH: "{@path}:/opt/homebrew/Cellar/php@8.4/8.4.20/bin"
         phpstan:
             run: vendor/bin/phpstan analyse --memory-limit=1G --no-progress
+            env:
+                PATH: "{@path}:/opt/homebrew/Cellar/php@8.4/8.4.20/bin"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,12 +7,6 @@ parameters:
 			path: src/BlogrServiceProvider.php
 
 		-
-			message: '#^Method Happytodev\\Blogr\\Contracts\\BlogrExtension@anonymous/BlogrServiceProvider\.php\:393\:\:getHomepage\(\) never returns null so it can be removed from the return type\.$#'
-			identifier: return.unusedType
-			count: 1
-			path: src/BlogrServiceProvider.php
-
-		-
 			message: '#^Result of && is always false\.$#'
 			identifier: booleanAnd.alwaysFalse
 			count: 1

--- a/resources/views/components/blocks/contact_form.blade.php
+++ b/resources/views/components/blocks/contact_form.blade.php
@@ -7,11 +7,42 @@
     $successMessage = $data['success_message'] ?? __('Thank you! Your message has been sent.');
     $toEmail = $data['to_email'] ?? config('blogr.contact.to_email', '');
     $uniqueId = 'contact-form-' . uniqid();
+
+    $image = $data['image'] ?? '';
+    $imageAlt = $data['image_alt'] ?? '';
+    $imagePosition = $data['image_position'] ?? 'right';
+    $imageWidth = (int)($data['image_width'] ?? 50);
+
+    $hasImage = !empty($image);
+
+    if ($hasImage) {
+        $gridCols = match($imageWidth) {
+            25, 75 => 'lg:grid-cols-4',
+            default => 'lg:grid-cols-2',
+        };
+
+        $formColSpan = match($imageWidth) {
+            25 => 'lg:col-span-3',
+            75 => 'lg:col-span-1',
+            default => 'lg:col-span-1',
+        };
+
+        $imageColSpan = match($imageWidth) {
+            25 => 'lg:col-span-1',
+            75 => 'lg:col-span-3',
+            default => 'lg:col-span-1',
+        };
+    }
+
+    $imagePath = $image;
+    if ($imagePath && !str_starts_with($imagePath, 'storage/')) {
+        $imagePath = 'storage/' . $imagePath;
+    }
 @endphp
 
 <div id="contact-form">
     <x-blogr::background-wrapper :data="$data">
-    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
         @if($heading || $subtitle)
             <div class="text-center mb-10">
                 @if($heading)
@@ -25,6 +56,23 @@
                     </p>
                 @endif
             </div>
+        @endif
+
+        @if($hasImage)
+            <div class="grid grid-cols-1 {{ $gridCols }} gap-8 lg:gap-12">
+                @if($imagePosition === 'left')
+                    {{-- Image first in DOM → stacks above form on mobile --}}
+                    <div class="{{ $imageColSpan }}">
+                        <img src="{{ asset($imagePath) }}"
+                             alt="{{ $imageAlt }}"
+                             class="w-full h-auto rounded-2xl shadow-lg object-cover"
+                             loading="lazy">
+                    </div>
+                    <div class="{{ $formColSpan }}">
+                @else
+                    {{-- Form first in DOM → stacks above image on mobile --}}
+                    <div class="{{ $formColSpan }}">
+                @endif
         @endif
 
         <div id="{{ $uniqueId }}" x-data="contactForm({
@@ -114,6 +162,21 @@
                 </template>
             </form>
         </div>
+
+        @if($hasImage)
+            @if($imagePosition === 'left')
+                    </div>
+            @else
+                    </div>
+                    <div class="{{ $imageColSpan }}">
+                        <img src="{{ asset($imagePath) }}"
+                             alt="{{ $imageAlt }}"
+                             class="w-full h-auto rounded-2xl shadow-lg object-cover"
+                             loading="lazy">
+                    </div>
+            @endif
+            </div>
+        @endif
     </div>
 
     <script>

--- a/resources/views/filament/pages/plugins.blade.php
+++ b/resources/views/filament/pages/plugins.blade.php
@@ -163,6 +163,35 @@
             text-align: center;
             padding: 5rem 0;
         }
+        .blogr-plugin-settings-btn {
+            flex-shrink: 0;
+            width: 32px;
+            height: 32px;
+            border-radius: 0.375rem;
+            border: none;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: transparent;
+            color: #9ca3af;
+            transition: color 0.15s ease, background-color 0.15s ease;
+            padding: 0;
+            outline: none;
+            text-decoration: none;
+        }
+        .blogr-plugin-settings-btn:hover {
+            color: #4f46e5;
+            background-color: #f3f4f6;
+        }
+        .dark .blogr-plugin-settings-btn:hover {
+            color: #818cf8;
+            background-color: #374151;
+        }
+        .blogr-plugin-settings-btn svg {
+            width: 18px;
+            height: 18px;
+        }
         .blogr-plugin-empty p {
             margin-top: 1rem;
             font-size: 1rem;
@@ -196,6 +225,117 @@
             gap: 0.5rem;
             flex-wrap: wrap;
         }
+        .blogr-plugin-actions {
+            display: flex;
+            align-items: center;
+            gap: 0.375rem;
+            flex-shrink: 0;
+        }
+        .blogr-community-section {
+            margin-top: 2.5rem;
+            padding-top: 1.5rem;
+            border-top: 2px solid #e5e7eb;
+        }
+        .dark .blogr-community-section {
+            border-top-color: #374151;
+        }
+        .blogr-community-title {
+            font-size: 1.125rem;
+            font-weight: 700;
+            color: #111827;
+            margin-bottom: 0.25rem;
+        }
+        .dark .blogr-community-title {
+            color: #e5e7eb;
+        }
+        .blogr-community-subtitle {
+            font-size: 0.875rem;
+            color: #6b7280;
+            margin-bottom: 1rem;
+        }
+        .dark .blogr-community-subtitle {
+            color: #9ca3af;
+        }
+        .blogr-community-card {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.875rem 1rem;
+            border-radius: 0.5rem;
+            background-color: #f9fafb;
+            border: 1px solid #e5e7eb;
+            margin-bottom: 0.5rem;
+        }
+        .dark .blogr-community-card {
+            background-color: #111827;
+            border-color: #374151;
+        }
+        .blogr-community-card:last-child {
+            margin-bottom: 0;
+        }
+        .blogr-community-card svg {
+            width: 20px;
+            height: 20px;
+            flex-shrink: 0;
+            color: #6b7280;
+        }
+        .blogr-community-card .info {
+            flex: 1;
+            min-width: 0;
+        }
+        .blogr-community-card .info .name {
+            font-weight: 600;
+            font-size: 0.875rem;
+            color: #111827;
+        }
+        .dark .blogr-community-card .info .name {
+            color: #e5e7eb;
+        }
+        .blogr-community-card .info .desc {
+            font-size: 0.8125rem;
+            color: #6b7280;
+        }
+        .blogr-community-card .repo-link {
+            font-size: 0.8125rem;
+            color: #4f46e5;
+            text-decoration: none;
+            font-family: ui-monospace, monospace;
+            flex-shrink: 0;
+        }
+        .dark .blogr-community-card .repo-link {
+            color: #818cf8;
+        }
+        .blogr-community-card .repo-link:hover {
+            text-decoration: underline;
+        }
+        .blogr-community-install-note {
+            font-size: 0.8125rem;
+            color: #9ca3af;
+            margin-bottom: 1rem;
+            line-height: 1.5;
+        }
+        .dark .blogr-community-install-note {
+            color: #6b7280;
+        }
+        .blogr-community-dev-link {
+            color: #4f46e5;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        .dark .blogr-community-dev-link {
+            color: #818cf8;
+        }
+        .blogr-community-dev-link:hover {
+            text-decoration: underline;
+        }
+        .blogr-community-dev-section {
+            margin-top: 0.5rem;
+            padding-top: 0.75rem;
+            border-top: 1px solid #f3f4f6;
+        }
+        .dark .blogr-community-dev-section {
+            border-top-color: #374151;
+        }
     </style>
 
     @if($pluginCount === 0)
@@ -227,21 +367,38 @@
                         </div>
                     </div>
 
-                    @if($isCore)
-                        <span class="blogr-plugin-toggle-core">Core</span>
-                    @else
-                        <button
-                            type="button"
-                            wire:click="toggleExtension('{{ $ext->getId() }}')"
-                            class="blogr-plugin-toggle @if(in_array($ext->getId(), $disabledIds)) blogr-plugin-toggle-off @else blogr-plugin-toggle-on @endif"
-                            role="switch"
-                            aria-checked="{{ in_array($ext->getId(), $disabledIds) ? 'false' : 'true' }}"
-                            aria-label="Toggle {{ $ext->getName() }}"
-                            title="{{ in_array($ext->getId(), $disabledIds) ? __('Disabled') : __('Active') }}"
-                        >
-                            <span class="blogr-plugin-toggle-knob"></span>
-                        </button>
-                    @endif
+                    <div class="blogr-plugin-actions">
+                        @php $settingsUrl = !in_array($ext->getId(), $disabledIds) ? $ext->getSettingsUrl() : null; @endphp
+                        @if(!$isCore && $settingsUrl)
+                            <a
+                                href="{{ $settingsUrl }}"
+                                class="blogr-plugin-settings-btn"
+                                title="{{ __('Settings') }}"
+                                aria-label="{{ __(':name settings', ['name' => $ext->getName()]) }}"
+                            >
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z"/>
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                                </svg>
+                            </a>
+                        @endif
+
+                        @if($isCore)
+                            <span class="blogr-plugin-toggle-core">Core</span>
+                        @else
+                            <button
+                                type="button"
+                                wire:click="toggleExtension('{{ $ext->getId() }}')"
+                                class="blogr-plugin-toggle @if(in_array($ext->getId(), $disabledIds)) blogr-plugin-toggle-off @else blogr-plugin-toggle-on @endif"
+                                role="switch"
+                                aria-checked="{{ in_array($ext->getId(), $disabledIds) ? 'false' : 'true' }}"
+                                aria-label="Toggle {{ $ext->getName() }}"
+                                title="{{ in_array($ext->getId(), $disabledIds) ? __('Disabled') : __('Active') }}"
+                            >
+                                <span class="blogr-plugin-toggle-knob"></span>
+                            </button>
+                        @endif
+                    </div>
                 </div>
 
                 <p class="blogr-plugin-description">{{ $ext->getDescription() }}</p>
@@ -264,5 +421,41 @@
                 </div>
             </div>
         @endforeach
+
+        @php $community = $this->getCommunityPlugins(); @endphp
+        @if(count($community) > 0)
+            <div class="blogr-community-section">
+                <div class="blogr-community-title">{{ __('Community Plugins') }}</div>
+                <div class="blogr-community-subtitle">{{ __('Discover more plugins from the Blogr community.') }}</div>
+                <p class="blogr-community-install-note">{{ __('Plugins are installed manually via Composer — refer to each plugin\'s documentation for instructions.') }}</p>
+
+                @foreach($community as $plugin)
+                    <div class="blogr-community-card">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"/>
+                        </svg>
+                        <div class="info">
+                            <div class="name">{{ $plugin['name'] }}</div>
+                            @if($plugin['description'])
+                                <div class="desc">{{ $plugin['description'] }}</div>
+                            @endif
+                        </div>
+                        <a href="{{ $plugin['url'] }}" target="_blank" rel="noopener noreferrer" class="repo-link">
+                            {{ $plugin['url'] }}
+                        </a>
+                    </div>
+                @endforeach
+
+                <div class="blogr-community-dev-section">
+                    <div class="blogr-community-title" style="margin-top: 1.5rem;">{{ __('Develop a Plugin') }}</div>
+                    <p class="blogr-community-install-note">{{ __('Create your own Blogr plugin by implementing the BlogrExtension interface. See the') }} <a href="https://github.com/happytodev/blogr?tab=readme-ov-file#developing-plugins" target="_blank" rel="noopener noreferrer" class="blogr-community-dev-link">{{ __('Developing Plugins guide') }}</a> {{ __('in the main Blogr README.') }}</p>
+                </div>
+            </div>
+        @else
+            <div class="blogr-community-section">
+                <div class="blogr-community-title">{{ __('Develop a Plugin') }}</div>
+                <p class="blogr-community-install-note">{{ __('Create your own Blogr plugin by implementing the BlogrExtension interface. See the') }} <a href="https://github.com/happytodev/blogr?tab=readme-ov-file#developing-plugins" target="_blank" rel="noopener noreferrer" class="blogr-community-dev-link">{{ __('Developing Plugins guide') }}</a> {{ __('in the main Blogr README.') }}</p>
+            </div>
+        @endif
     @endif
 </x-filament-panels::page>

--- a/src/BlogrServiceProvider.php
+++ b/src/BlogrServiceProvider.php
@@ -23,6 +23,7 @@ use Happytodev\Blogr\Commands\SyncAdminPathCommand;
 use Happytodev\Blogr\Concerns\RegistersLinkTypes;
 use Happytodev\Blogr\Contracts\BlogrExtension;
 use Happytodev\Blogr\Filament\Livewire\AuthorBio;
+use Happytodev\Blogr\Filament\Pages\BlogrSettings;
 use Happytodev\Blogr\Filament\Widgets\BlogPostsChart;
 use Happytodev\Blogr\Filament\Widgets\BlogReadingStats;
 use Happytodev\Blogr\Filament\Widgets\BlogStatsOverview;
@@ -301,13 +302,17 @@ class BlogrServiceProvider extends PackageServiceProvider
             $this->repairStalePublishedViews();
         }
 
-        // Register link types from all enabled extensions
+        // Register enabled extensions and their link types
         $this->app->booted(function (): void {
-            $registry = $this->app->make(LinkTypeRegistry::class);
-            $extensions = $this->app->make(ExtensionRegistry::class)->getEnabled();
+            $extensionRegistry = $this->app->make(ExtensionRegistry::class);
+            $linkTypeRegistry = $this->app->make(LinkTypeRegistry::class);
 
-            foreach ($extensions as $extension) {
-                $extension->registerLinkTypes($registry);
+            foreach ($extensionRegistry->getEnabled() as $extension) {
+                $extension->registerExtension($extensionRegistry);
+            }
+
+            foreach ($extensionRegistry->getEnabled() as $extension) {
+                $extension->registerLinkTypes($linkTypeRegistry);
             }
         });
     }
@@ -419,7 +424,7 @@ class BlogrServiceProvider extends PackageServiceProvider
                 return 'HappyToDev';
             }
 
-            public function getHomepage(): ?string
+            public function getHomepage(): string
             {
                 return 'https://github.com/happytodev/blogr';
             }
@@ -427,6 +432,11 @@ class BlogrServiceProvider extends PackageServiceProvider
             public function getDependencies(): array
             {
                 return [];
+            }
+
+            public function getSettingsUrl(): string
+            {
+                return BlogrSettings::getUrl();
             }
         });
     }

--- a/src/Concerns/RegistersLinkTypes.php
+++ b/src/Concerns/RegistersLinkTypes.php
@@ -2,9 +2,17 @@
 
 namespace Happytodev\Blogr\Concerns;
 
+use Happytodev\Blogr\Services\ExtensionRegistry;
 use Happytodev\Blogr\Services\LinkTypeRegistry;
 
 trait RegistersLinkTypes
 {
+    public function getSettingsUrl(): ?string
+    {
+        return null;
+    }
+
+    public function registerExtension(ExtensionRegistry $registry): void {}
+
     public function registerLinkTypes(LinkTypeRegistry $registry): void {}
 }

--- a/src/Contracts/BlogrExtension.php
+++ b/src/Contracts/BlogrExtension.php
@@ -2,49 +2,28 @@
 
 namespace Happytodev\Blogr\Contracts;
 
+use Happytodev\Blogr\Services\ExtensionRegistry;
 use Happytodev\Blogr\Services\LinkTypeRegistry;
 
 interface BlogrExtension
 {
-    /**
-     * Unique identifier for the extension (e.g., 'blogr-gdpr').
-     */
     public function getId(): string;
 
-    /**
-     * Human-readable name (e.g., 'GDPR Compliance').
-     */
     public function getName(): string;
 
-    /**
-     * Short description of what the extension does.
-     */
     public function getDescription(): string;
 
-    /**
-     * Current version (e.g., '1.0.0').
-     */
     public function getVersion(): string;
 
-    /**
-     * Author name or organization.
-     */
     public function getAuthor(): string;
 
-    /**
-     * Optional URL to the extension's homepage or repository.
-     */
     public function getHomepage(): ?string;
 
-    /**
-     * Optional array of extension IDs that this extension depends on.
-     *
-     * @return string[]
-     */
     public function getDependencies(): array;
 
-    /**
-     * Register link types for the navigation & CMS link selector.
-     */
+    public function getSettingsUrl(): ?string;
+
+    public function registerExtension(ExtensionRegistry $registry): void;
+
     public function registerLinkTypes(LinkTypeRegistry $registry): void;
 }

--- a/src/Filament/Pages/Plugins.php
+++ b/src/Filament/Pages/Plugins.php
@@ -5,6 +5,8 @@ namespace Happytodev\Blogr\Filament\Pages;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Happytodev\Blogr\Services\ExtensionRegistry;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 
 class Plugins extends Page
 {
@@ -72,6 +74,176 @@ class Plugins extends Page
                 ->success()
                 ->send();
         }
+    }
+
+    /**
+     * @return array<int, array{name: string, description: string, url: string}>
+     */
+    public function getCommunityPlugins(): array
+    {
+        $discovered = Cache::remember('blogr:community-plugins', 86400, function () {
+            return $this->fetchCommunityPlugins();
+        });
+
+        return $this->filterInstalledPlugins($discovered);
+    }
+
+    /**
+     * @param  array<int, array{name: string, description: string, url: string}>  $plugins
+     * @return array<int, array{name: string, description: string, url: string}>
+     */
+    protected function filterInstalledPlugins(array $plugins): array
+    {
+        $installed = app(ExtensionRegistry::class)->getAll();
+
+        return array_values(array_filter($plugins, function (array $plugin) use ($installed): bool {
+            $repoName = $this->extractRepoName($plugin['url']);
+
+            foreach ($installed as $extension) {
+                // Match by extension ID (e.g. 'blogr-gdpr' from 'happytodev/blogr-gdpr')
+                if ($repoName !== null && $extension->getId() === $repoName) {
+                    return false;
+                }
+
+                // Match by homepage URL
+                if ($extension->getHomepage() === $plugin['url']) {
+                    return false;
+                }
+            }
+
+            return true;
+        }));
+    }
+
+    protected function extractRepoName(string $url): ?string
+    {
+        // Extract 'blogr-gdpr' from 'https://github.com/happytodev/blogr-gdpr'
+        if (preg_match('#/([^/]+?)(?:\.git)?$#', $url, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, array{name: string, description: string, url: string}>
+     */
+    protected function fetchCommunityPlugins(): array
+    {
+        // Try local README first (covers development and vendored installs)
+        $localPath = __DIR__.'/../../../README.md';
+
+        if (file_exists($localPath)) {
+            $content = file_get_contents($localPath);
+
+            if ($content !== false) {
+                $plugins = $this->parsePluginTable($content);
+
+                if ($plugins !== []) {
+                    return $plugins;
+                }
+            }
+        }
+
+        // Fallback: fetch from GitHub for the latest community listing
+        try {
+            $response = Http::timeout(5)->get('https://raw.githubusercontent.com/happytodev/blogr/main/README.md');
+
+            if ($response->successful()) {
+                return $this->parsePluginTable($response->body());
+            }
+        } catch (\Throwable) {
+            // Silently fail
+        }
+
+        return [];
+    }
+
+    /**
+     * @return array<int, array{name: string, description: string, url: string}>
+     */
+    protected function parsePluginTable(string $markdown): array
+    {
+        $plugins = [];
+        $lines = explode("\n", $markdown);
+        $inSection = false;
+        $inTable = false;
+
+        foreach ($lines as $line) {
+            $trimmed = trim($line);
+
+            // Detect start of ## Plugins section
+            if (preg_match('/^##\s+Plugins\s*$/', $trimmed)) {
+                $inSection = true;
+                $inTable = false;
+
+                continue;
+            }
+
+            if (! $inSection) {
+                continue;
+            }
+
+            // End of section: next heading or horizontal rule
+            if (preg_match('/^##/', $trimmed) || preg_match('/^---+$/', $trimmed)) {
+                break;
+            }
+
+            // Skip blank lines
+            if ($trimmed === '') {
+                continue;
+            }
+
+            // Detect pipe table rows
+            if (str_starts_with($trimmed, '|')) {
+                // Skip separator row (|---|---|---)
+                if (preg_match('/^\|[\s\-:]+\|$/', $trimmed)) {
+                    $inTable = true;
+
+                    continue;
+                }
+
+                $inTable = true;
+
+                $columns = explode('|', $trimmed);
+                $columns = array_map(fn ($c) => trim($c), $columns);
+                $columns = array_values(array_filter($columns, fn ($c) => $c !== ''));
+
+                if (count($columns) >= 3) {
+                    $name = strip_tags($columns[0]);
+                    $description = strip_tags($columns[1]);
+                    $url = $this->extractUrl($columns[2]);
+
+                    if ($name !== '' && $url !== '') {
+                        $plugins[] = [
+                            'name' => html_entity_decode($name),
+                            'description' => html_entity_decode($description),
+                            'url' => $url,
+                        ];
+                    }
+                }
+            } elseif ($inTable) {
+                // Table ended by non-pipe content
+                break;
+            }
+        }
+
+        return $plugins;
+    }
+
+    protected function extractUrl(string $cell): string
+    {
+        // Extract URL from markdown link: [text](url)
+        if (preg_match('/\[([^\]]+)\]\(([^)]+)\)/', $cell, $matches)) {
+            return $matches[2];
+        }
+
+        // Fallback: raw URL
+        if (preg_match('/https?:\/\/[^\s]+/', $cell, $matches)) {
+            return $matches[0];
+        }
+
+        return '';
     }
 
     private function getExtensionName(string $id): string

--- a/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
+++ b/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
@@ -1053,6 +1053,40 @@ class CmsBlockBuilder
                             ->label(__('Send To Email (leave empty for site default)'))
                             ->email()
                             ->columnSpan(2),
+
+                        FileUpload::make('image')
+                            ->label(__('Side Image'))
+                            ->image()
+                            ->disk('public')
+                            ->directory('cms-blocks/contact')
+                            ->visibility('public')
+                            ->imageEditor()
+                            ->helperText(__('Appears alongside the contact form in a two-column layout'))
+                            ->columnSpan(2),
+
+                        TextInput::make('image_alt')
+                            ->label(__('Image Alt Text'))
+                            ->maxLength(255)
+                            ->columnSpan(1),
+
+                        Select::make('image_position')
+                            ->label(__('Image Position'))
+                            ->options([
+                                'right' => __('Right (form left, image right)'),
+                                'left' => __('Left (image left, form right)'),
+                            ])
+                            ->default('right')
+                            ->columnSpan(1),
+
+                        Select::make('image_width')
+                            ->label(__('Image Width'))
+                            ->options([
+                                25 => '25%',
+                                50 => '50%',
+                                75 => '75%',
+                            ])
+                            ->default(50)
+                            ->columnSpan(1),
                     ])
                     ->columns(2),
 

--- a/src/Services/ExtensionRegistry.php
+++ b/src/Services/ExtensionRegistry.php
@@ -99,8 +99,6 @@ class ExtensionRegistry
             return;
         }
 
-        $this->loadedFromDb = true;
-
         if (! $this->hasDbTable()) {
             return;
         }
@@ -113,6 +111,8 @@ class ExtensionRegistry
                 ->map(fn () => true)
                 ->toArray();
         });
+
+        $this->loadedFromDb = true;
     }
 
     protected function hasDbTable(): bool

--- a/src/Services/Translation/BlockTranslator.php
+++ b/src/Services/Translation/BlockTranslator.php
@@ -22,7 +22,7 @@ class BlockTranslator
         'blog_posts' => ['heading'],
         'blog-title' => ['title', 'description'],
         'map' => ['heading', 'subtitle', 'tagline'],
-        'contact_form' => ['heading', 'subtitle', 'submit_text', 'success_message'],
+        'contact_form' => ['heading', 'subtitle', 'submit_text', 'success_message', 'image_alt'],
     ];
 
     public function __construct(protected TranslationProvider $provider) {}

--- a/tests/Feature/Cms/CmsContactPageTest.php
+++ b/tests/Feature/Cms/CmsContactPageTest.php
@@ -266,6 +266,131 @@ test('contact_form block has light and dark mode colors', function () {
 });
 
 // ──────────────────────────────────────────────
+// Contact form block — image layout
+// ──────────────────────────────────────────────
+
+test('contact_form block builder has image fields in source', function () {
+    $path = projectRoot().'/src/Filament/Resources/CmsPages/CmsBlockBuilder.php';
+    $content = file_get_contents($path);
+
+    // The contactFormBlock method must define the 4 new fields
+    expect($content)->toMatch('/FileUpload::make\(\'image\'\)/');
+    expect($content)->toMatch('/TextInput::make\(\'image_alt\'\)/');
+    expect($content)->toMatch('/Select::make\(\'image_position\'\)/');
+    expect($content)->toMatch('/Select::make\(\'image_width\'\)/');
+});
+
+test('contact_form block renders without error when image is absent', function () {
+    $data = [
+        'heading' => 'Contact',
+        'submit_text' => 'Send',
+        'success_message' => 'Thanks!',
+    ];
+
+    $html = view('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    // Form must still render normally
+    expect($html)->toContain('bg-indigo-600');
+    expect($html)->toContain('text-white');
+    // No image-related grid class when image is absent
+    expect($html)->not->toContain('lg:grid-cols-2');
+    expect($html)->not->toContain('lg:grid-cols-4');
+});
+
+test('contact_form block renders image when image is set', function () {
+    $data = [
+        'heading' => 'Contact',
+        'submit_text' => 'Send',
+        'success_message' => 'Thanks!',
+        'image' => 'cms-blocks/contact/photo.jpg',
+        'image_alt' => 'Our office',
+        'image_width' => 50,
+        'image_position' => 'right',
+    ];
+
+    $html = view('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    expect($html)->toContain('Our office');
+    expect($html)->toContain('lg:grid-cols-2');
+});
+
+test('contact_form block respects image_position left (image first in DOM)', function () {
+    $data = [
+        'heading' => 'Contact',
+        'image' => 'cms-blocks/contact/photo.jpg',
+        'image_alt' => 'Office',
+        'image_width' => 50,
+        'image_position' => 'left',
+    ];
+
+    $html = view('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    // Image alt text should appear before any form input when image is left
+    $officePos = strpos($html, 'Office');
+    $indigoPos = strpos($html, 'bg-indigo-600');
+    expect($officePos)->not->toBeFalse();
+    expect($indigoPos)->not->toBeFalse();
+    expect($officePos)->toBeLessThan($indigoPos);
+});
+
+test('contact_form block renders image_50 with grid-cols-2', function () {
+    $data = [
+        'image' => 'cms-blocks/contact/photo.jpg',
+        'image_alt' => 'Office',
+        'image_width' => 50,
+        'image_position' => 'right',
+    ];
+
+    $html = view('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    expect($html)->toContain('lg:grid-cols-2');
+    expect($html)->not->toContain('lg:grid-cols-4');
+});
+
+test('contact_form block renders image_width 25 with col-span-3 form', function () {
+    $data = [
+        'image' => 'cms-blocks/contact/photo.jpg',
+        'image_alt' => 'Office',
+        'image_width' => 25,
+        'image_position' => 'right',
+    ];
+
+    $html = view('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    expect($html)->toContain('lg:grid-cols-4');
+    expect($html)->toContain('lg:col-span-3');
+    expect($html)->toContain('lg:col-span-1');
+});
+
+test('contact_form block renders image_width 75 with col-span-3 image', function () {
+    $data = [
+        'image' => 'cms-blocks/contact/photo.jpg',
+        'image_alt' => 'Office',
+        'image_width' => 75,
+        'image_position' => 'right',
+    ];
+
+    $html = view('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    expect($html)->toContain('lg:grid-cols-4');
+    expect($html)->toContain('lg:col-span-1');
+    expect($html)->toContain('lg:col-span-3');
+});
+
+test('contact_form block renders image_alt text', function () {
+    $data = [
+        'image' => 'cms-blocks/contact/photo.jpg',
+        'image_alt' => 'Modern office building with reception area',
+        'image_width' => 50,
+        'image_position' => 'right',
+    ];
+
+    $html = view('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    expect($html)->toContain('Modern office building with reception area');
+});
+
+// ──────────────────────────────────────────────
 // Features block — no chat, X + Bluesky
 // ──────────────────────────────────────────────
 

--- a/tests/Unit/ExtensionRegistryTest.php
+++ b/tests/Unit/ExtensionRegistryTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use Happytodev\Blogr\Concerns\RegistersLinkTypes;
 use Happytodev\Blogr\Contracts\BlogrExtension;
 use Happytodev\Blogr\Filament\Pages\Plugins;
 use Happytodev\Blogr\Services\ExtensionRegistry;
-use Happytodev\Blogr\Services\LinkTypeRegistry;
 
 // ─── BlogrExtension INTERFACE ─────────────────────────
 
@@ -23,6 +23,8 @@ test('BlogrExtension interface has required methods', function () {
     expect($methodNames)->toContain('getAuthor');
     expect($methodNames)->toContain('getHomepage');
     expect($methodNames)->toContain('getDependencies');
+    expect($methodNames)->toContain('getSettingsUrl');
+    expect($methodNames)->toContain('registerExtension');
     expect($methodNames)->toContain('registerLinkTypes');
 });
 
@@ -68,7 +70,7 @@ test('ExtensionRegistry can register and retrieve extensions', function () {
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     $registry->register($extension);
@@ -125,7 +127,7 @@ test('ExtensionRegistry can list all extensions', function () {
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     $ext2 = new class implements BlogrExtension
@@ -165,7 +167,7 @@ test('ExtensionRegistry can list all extensions', function () {
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     $registry->register($ext1);
@@ -220,7 +222,7 @@ test('ExtensionRegistry can count extensions', function () {
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     $registry->register($ext);
@@ -267,7 +269,7 @@ test('registering extension with same id overwrites previous', function () {
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     $ext2 = new class implements BlogrExtension
@@ -307,7 +309,7 @@ test('registering extension with same id overwrites previous', function () {
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     $registry->register($ext1);
@@ -355,7 +357,7 @@ test('extension can have dependencies', function () {
             return ['blogr-core', 'blogr-gdpr'];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     expect($ext->getDependencies())->toBe(['blogr-core', 'blogr-gdpr']);
@@ -399,7 +401,7 @@ test('extension can have null homepage', function () {
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     expect($ext->getHomepage())->toBeNull();
@@ -540,7 +542,7 @@ test('registering extension auto-creates enabled state', function () {
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     $registry->register($ext);
@@ -588,7 +590,7 @@ test('toggleExtension in Plugins page toggles state for non-core extensions', fu
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     $registry->register($ext);
@@ -652,7 +654,7 @@ test('toggling non-core extension twice restores enabled', function () {
             return [];
         }
 
-        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+        use RegistersLinkTypes;
     };
 
     $registry->register($ext);
@@ -663,4 +665,234 @@ test('toggling non-core extension twice restores enabled', function () {
 
     $page->toggleExtension('ext-three');
     expect($registry->isEnabled('ext-three'))->toBeTrue();
+});
+
+// ─── LIFECYCLE: register / boot / getSettingsUrl ──────
+
+test('getSettingsUrl returns null by default', function () {
+    $ext = new class implements BlogrExtension
+    {
+        use RegistersLinkTypes;
+
+        public function getId(): string
+        {
+            return 'settings-test';
+        }
+
+        public function getName(): string
+        {
+            return 'Settings Test';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Dev';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+    };
+
+    expect($ext->getSettingsUrl())->toBeNull();
+});
+
+test('registerExtension is called on enabled extensions', function () {
+    $registry = app(ExtensionRegistry::class);
+
+    $tracker = new stdClass;
+    $tracker->registerCalled = false;
+
+    $ext = new class($tracker) implements BlogrExtension
+    {
+        use RegistersLinkTypes;
+
+        public function __construct(private stdClass $tracker) {}
+
+        public function getId(): string
+        {
+            return 'lifecycle-track';
+        }
+
+        public function getName(): string
+        {
+            return 'Lifecycle Track';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Dev';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function registerExtension(ExtensionRegistry $registry): void
+        {
+            $this->tracker->registerCalled = true;
+        }
+    };
+
+    $registry->register($ext);
+
+    // Simulate the app->booted() lifecycle from BlogrServiceProvider
+    foreach ($registry->getEnabled() as $ext) {
+        $ext->registerExtension($registry);
+    }
+
+    expect($tracker->registerCalled)->toBeTrue();
+});
+
+test('registerExtension is NOT called on disabled extensions', function () {
+    $registry = app(ExtensionRegistry::class);
+
+    $tracker = new stdClass;
+    $tracker->registerCalled = false;
+
+    $ext = new class($tracker) implements BlogrExtension
+    {
+        use RegistersLinkTypes;
+
+        public function __construct(private stdClass $tracker) {}
+
+        public function getId(): string
+        {
+            return 'lifecycle-disabled';
+        }
+
+        public function getName(): string
+        {
+            return 'Lifecycle Disabled';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Dev';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function registerExtension(ExtensionRegistry $registry): void
+        {
+            $this->tracker->registerCalled = true;
+        }
+    };
+
+    $registry->register($ext);
+    $registry->disable('lifecycle-disabled');
+
+    // Only enabled extensions should have register called
+    foreach ($registry->getEnabled() as $ext) {
+        $ext->registerExtension($registry);
+    }
+
+    expect($tracker->registerCalled)->toBeFalse();
+
+    $registry->enable('lifecycle-disabled');
+});
+
+// ─── COMMUNITY PLUGIN DISCOVERY ─────────────────────
+
+test('parsePluginTable extracts plugins from markdown', function () {
+    $page = new Plugins;
+
+    $reflection = new ReflectionMethod($page, 'parsePluginTable');
+    $reflection->setAccessible(true);
+
+    $markdown = <<<'MD'
+## Plugins
+
+| Plugin | Description | Repository |
+|--------|-------------|------------|
+| GDPR | Cookie consent, privacy, data export | [happytodev/blogr-gdpr](https://github.com/happytodev/blogr-gdpr) |
+| SEO | Search engine optimization | [happytodev/blogr-seo](https://github.com/happytodev/blogr-seo) |
+
+## Next Section
+MD;
+
+    $result = $reflection->invoke($page, $markdown);
+
+    expect($result)->toHaveCount(2);
+    expect($result[0]['name'])->toBe('GDPR');
+    expect($result[0]['description'])->toBe('Cookie consent, privacy, data export');
+    expect($result[0]['url'])->toBe('https://github.com/happytodev/blogr-gdpr');
+    expect($result[1]['name'])->toBe('SEO');
+    expect($result[1]['url'])->toBe('https://github.com/happytodev/blogr-seo');
+});
+
+test('parsePluginTable returns empty array when no plugins section', function () {
+    $page = new Plugins;
+
+    $reflection = new ReflectionMethod($page, 'parsePluginTable');
+    $reflection->setAccessible(true);
+
+    $markdown = "# Just a normal readme\n\nNo plugins here.\n";
+
+    $result = $reflection->invoke($page, $markdown);
+
+    expect($result)->toBe([]);
+});
+
+test('parsePluginTable returns empty array for empty table', function () {
+    $page = new Plugins;
+
+    $reflection = new ReflectionMethod($page, 'parsePluginTable');
+    $reflection->setAccessible(true);
+
+    $markdown = "## Plugins\n\n| Plugin | Description | Repository |\n|--------|-------------|------------|\n";
+
+    $result = $reflection->invoke($page, $markdown);
+
+    expect($result)->toBe([]);
 });


### PR DESCRIPTION
## Summary

Overhaul of the plugin system across 4 packages.

### Plugin system (blogr)
- BlogrExtension interface: add getSettingsUrl() and registerExtension() 
- ExtensionRegistry: fix loadedFromDb flag set before DB load
- Feature-gating: app->booted() calls registerExtension() on enabled extensions
- Plugins page: settings icon, community plugins discovery, develop section

### Plugin gating (artist, comments, gdpr)
- register(Panel) queries blogr_extension_states directly (bypasses singleton timing)
- moved to register() phase via afterResolving(PanelRegistry)
- shouldRegisterNavigation() on settings pages
- getSettingsUrl() wraps SettingsPage::getUrl() in try/catch

### Docs
- README: plugins table, Developing Plugins section
- CHANGELOG recorded

## Test plan
- vendor/bin/pest tests/Unit/ExtensionRegistryTest.php - 31 pass
- blogr-artist - 23 pass, blogr-comments - 10 pass, blogr-gdpr - 69 pass
- Toggle each plugin on Plugins page - verify navigation follows