### PR TITLE
fix(cms): collapse blocks by default, expand section, sort alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ All notable changes to `blogr` will be documented in this file.
 
 - **Blocks**: fix `str_starts_with()` type error when image is an array from Filament FileUpload in hero and contact_form blocks
 - **Blocks**: fix hero "Top (Behind Text)" image position — image now renders as full-bleed background behind text with WCAG gradient overlay
+- **CMS**: Content Blocks section is now expanded by default when editing a page translation
+- **CMS**: blocks are now collapsed by default to make navigation easier
+- **CMS**: block types are now sorted alphabetically in the add-block picker
 
 ### 🧪 Tests
 
 - **Blocks**: add tests for hero block array image handling, top position rendering, and contact_form array image handling
+- **CMS**: add tests for collapsed-by-default and alphabetical sort of blocks
 
 ## [v1.20.0](https://github.com/happytodev/blogr/compare/v1.19.0...v1.20.0) - 2026-06-29
 

--- a/src/Filament/Resources/CmsPageResource/Pages/EditCmsPageTranslation.php
+++ b/src/Filament/Resources/CmsPageResource/Pages/EditCmsPageTranslation.php
@@ -104,7 +104,6 @@ class EditCmsPageTranslation extends EditRecord
                     CmsBlockBuilder::make(),
                 ])
                 ->collapsible()
-                ->collapsed()
                 ->columnSpan(2),
 
             View::make('blogr::components.auto-save-indicator'),

--- a/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
+++ b/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
@@ -22,34 +22,44 @@ class CmsBlockBuilder
 {
     use LinkFieldsTrait;
 
+    public static function getSortedBlockDefinitions(): array
+    {
+        $blocks = [
+            self::heroBlock(),
+            self::featuresBlock(),
+            self::testimonialsBlock(),
+            self::ctaBlock(),
+            self::contentBlock(),
+            self::faqBlock(),
+            self::galleryBlock(),
+            self::teamBlock(),
+            self::pricingBlock(),
+            self::blogPostsBlock(),
+            self::statsBlock(),
+            self::timelineBlock(),
+            self::videoBlock(),
+            self::newsletterBlock(),
+            self::mapBlock(),
+            self::contactFormBlock(),
+            self::carouselBlock(),
+            self::pricingCommissionsBlock(),
+            self::artistBioBlock(),
+            self::transitionDiagonalBlock(),
+            self::blogTitleBlock(),
+        ];
+
+        usort($blocks, fn (Block $a, Block $b) => strcmp($a->getLabel(), $b->getLabel()));
+
+        return $blocks;
+    }
+
     public static function make(): Builder
     {
         return Builder::make('blocks')
             ->label(__('Content Blocks'))
-            ->blocks([
-                self::heroBlock(),
-                self::featuresBlock(),
-                self::testimonialsBlock(),
-                self::ctaBlock(),
-                self::contentBlock(),
-                self::faqBlock(),
-                self::galleryBlock(),
-                self::teamBlock(),
-                self::pricingBlock(),
-                self::blogPostsBlock(),
-                self::statsBlock(),
-                self::timelineBlock(),
-                self::videoBlock(),
-                self::newsletterBlock(),
-                self::mapBlock(),
-                self::contactFormBlock(),
-                self::carouselBlock(),
-                self::pricingCommissionsBlock(),
-                self::artistBioBlock(),
-                self::transitionDiagonalBlock(),
-                self::blogTitleBlock(),
-            ])
+            ->blocks(self::getSortedBlockDefinitions())
             ->collapsible()
+            ->collapsed()
             ->blockNumbers(false)
             ->lazy()
             ->columnSpanFull();

--- a/tests/Feature/Cms/CmsPageBlocksTest.php
+++ b/tests/Feature/Cms/CmsPageBlocksTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Happytodev\Blogr\Enums\CmsPageTemplate;
+use Happytodev\Blogr\Filament\Resources\CmsPages\CmsBlockBuilder;
 use Happytodev\Blogr\Models\CmsPage;
 use Happytodev\Blogr\Tests\CmsTestCase;
 
@@ -546,4 +547,19 @@ test('it can render team block', function () {
     expect($view)->toContain('Jane Smith');
     expect($view)->toContain('CTO');
     expect($view)->toContain('linkedin.com/in/johndoe');
+});
+
+test('blocks are collapsed by default in CmsBlockBuilder', function () {
+    $builder = CmsBlockBuilder::make();
+
+    expect($builder->isCollapsed())->toBeTrue();
+});
+
+test('blocks are sorted alphabetically by label in CmsBlockBuilder', function () {
+    $blocks = CmsBlockBuilder::getSortedBlockDefinitions();
+    $labels = array_map(fn ($block) => $block->getLabel(), $blocks);
+    $sortedLabels = $labels;
+    sort($sortedLabels);
+
+    expect($labels)->toBe($sortedLabels);
 });


### PR DESCRIPTION
## Summary

Three related fixes for the CMS page block editor:

1. **Content Blocks section** now stays **expanded** by default when editing a page translation — no extra click needed to see the block structure
2. **Individual blocks** are now **collapsed by default** — easier to scan all block names and expand only the one you need
3. **Block types** in the add-block picker are now **sorted alphabetically** by label

## CHANGELOG

### Fixed
- Content Blocks section is now expanded by default when editing a page translation
- blocks are now collapsed by default to make navigation easier
- block types are now sorted alphabetically in the add-block picker

### Tests
- add tests for collapsed-by-default and alphabetical sort of blocks

## Test plan

- [x] `vendor/bin/pest --parallel`
- [x] New tests pass: `blocks are collapsed by default in CmsBlockBuilder` / `blocks are sorted alphabetically by label in CmsBlockBuilder`

Closes #245, #246