### PR TITLE
fix(blocks): override light background with theme dark when background_type_dark is none

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ FilamentPHP v4 plugin package (`happytodev/blogr`) — a multilingual blog syste
 
 PHP/Composer binaries are installed via Homebrew at `/opt/homebrew/bin/`.
 Node/npm is installed via nvm at `~/.nvm/versions/node/*/bin/`.
+GitHub CLI (`gh`) is also at `/opt/homebrew/bin/gh`.
 The opencode shell may not include these directories in `PATH` automatically.
 Always ensure it is set before running any PHP, Composer, or Node commands:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to `blogr` will be documented in this file.
 - **Settings**: increase PHP memory limit to 512M to prevent out-of-memory errors in Livewire tests rendering the full settings page
 - **Settings**: add lazy loading to 7 tabs (SEO, Appearance, Content, Navigation, Analytics, Backup, AI Translation) to improve initial page load performance
 - **Blocks**: remove test files accidentally included in wrong PR
+- **Blocks**: override light mode background with theme dark color when `background_type_dark` is "none" — fixes white background appearing in dark mode
+- **Theme**: add `background-color` on `<main>` so transparent blocks properly inherit the theme's default background
 
 ### ✨ Added
 

--- a/resources/views/components/background-wrapper.blade.php
+++ b/resources/views/components/background-wrapper.blade.php
@@ -97,7 +97,12 @@
     }
     
     // Build dark mode styles
-    if ($backgroundTypeDark && $backgroundTypeDark !== 'none') {
+    if ($backgroundTypeDark === 'none') {
+        // Override light mode background with theme dark when dark mode is active
+        if (!empty($styles)) {
+            $darkStyles[] = "background-color: var(--color-bg-dark)";
+        }
+    } elseif ($backgroundTypeDark && $backgroundTypeDark !== 'none') {
         if ($backgroundTypeDark === 'color' && isset($data['background_color_dark'])) {
             $opacity = ($data['background_opacity_dark'] ?? 100) / 100;
             $color = $data['background_color_dark'];

--- a/resources/views/layouts/blog.blade.php
+++ b/resources/views/layouts/blog.blade.php
@@ -230,6 +230,14 @@
             font-family: var(--font-family), ui-sans-serif, system-ui, sans-serif;
         }
 
+        main {
+            background-color: var(--color-bg);
+            transition: background-color 0.3s, color 0.3s;
+        }
+        .dark main {
+            background-color: var(--color-bg-dark);
+        }
+
         .dark {
             --color-header-bg: var(--_header-bg-dark, var(--color-bg-dark));
             --color-header-text: var(--_header-text-dark, var(--color-text-dark));


### PR DESCRIPTION
## Summary

Fixes white background appearing in dark mode when a block's
`background_type_dark` is set to "none" but light mode has a
background color defined. Two changes:

1. **background-wrapper.blade.php**: When `background_type_dark`
   is "none" and a light mode background exists, inject a
   `.dark #id { background-color: var(--color-bg-dark) !important; }`
   override so the light color doesn't persist in dark mode.

2. **blog.blade.php**: Add `background-color: var(--color-bg/dark)`
   on `<main>` so blocks with transparent background ("none")
   always inherit the theme's default background color.

## CHANGELOG

- **Blocks**: override light mode background with theme dark color when
  `background_type_dark` is "none" — fixes white background appearing in dark mode
- **Theme**: add `background-color` on `<main>` so transparent blocks
  properly inherit the theme's default background

## Test plan

- [x] `vendor/bin/pest --parallel` — 1307 passed
- [x] Verified on preview URL — dark mode block now shows `--color-bg-dark`