### PR TITLE
fix(cms): require confirmation before deleting a CMS block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
-No unreleased changes yet.
+### 🐛 Fixed
+
+- **CMS**: deleting a block now requires confirmation to prevent accidental removals (#254)
 
 ## [v1.23.0](https://github.com/happytodev/blogr/compare/v1.22.0...v1.23.0) - 2026-07-01
 

--- a/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
+++ b/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
@@ -70,7 +70,8 @@ class CmsBlockBuilder
             ->extraItemActions([
                 self::toggleVisibilityAction(),
                 self::copyBlockAction(),
-            ]);
+            ])
+            ->deleteAction(fn (Action $action) => $action->requiresConfirmation());
     }
 
     protected static function heroBlock(): Block

--- a/tests/Feature/Cms/CmsBlockBuilderDeleteConfirmationTest.php
+++ b/tests/Feature/Cms/CmsBlockBuilderDeleteConfirmationTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Happytodev\Blogr\Filament\Resources\CmsPages\CmsBlockBuilder;
+use Happytodev\Blogr\Tests\CmsTestCase;
+
+uses(CmsTestCase::class);
+
+test('regression_254_block_delete_requires_confirmation', function () {
+    $builder = CmsBlockBuilder::make();
+
+    $deleteAction = $builder->getDeleteAction();
+
+    expect($deleteAction->isConfirmationRequired())->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Deleting a CMS content block now requires a confirmation modal before the block is permanently removed. This prevents accidental loss of potentially complex blocks (hero, pricing, gallery, etc.).

Closes #254.

## Changes

- Updated `CmsBlockBuilder::make()` to configure the native Filament Builder delete action with `requiresConfirmation()`.
- Added regression test `regression_254_block_delete_requires_confirmation`.

## Test plan

- [x] `vendor/bin/pest --filter regression_254_block_delete_requires_confirmation` passes
- [x] Anti-false-positive gate verified
- [x] `vendor/bin/pest --parallel` passes (1309 tests)
