### PR TITLE
fix(readme): restore community plugin table for admin panel parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Each block supports 5 background types (none, solid, gradient, image, pattern), 
 
 ---
 
-## 🔌 Plugins & Extensions
+## Plugins
 
 Blogr supports third-party plugins via the `BlogrExtension` interface. Plugins can register routes, Livewire components, custom link types, and settings pages.
 
@@ -360,7 +360,11 @@ public function packageBooted(): void
 }
 ```
 
-Known community plugins include GDPR, Comments, and Artist Portfolio packages.
+| Plugin | Description | Repository |
+|--------|-------------|------------|
+| GDPR | Cookie consent, privacy policy, data export and erasure | [happytodev/blogr-gdpr](https://github.com/happytodev/blogr-gdpr) |
+| Comments | Threaded comments with moderation, voting, anti-spam, and email notifications | [happytodev/blogr-comments](https://github.com/happytodev/blogr-comments) |
+| Artist Portfolio | Artist portfolio with artwork management, portfolio pages, and commission showcase | [happytodev/blogr-artist](https://github.com/happytodev/blogr-artist) |
 
 ---
 


### PR DESCRIPTION
## Summary

The Plugins admin page parses the README.md to discover and display community plugins. The recent README rewrite broke this by:
- Renaming `## Plugins` to `## 🔌 Plugins & Extensions` (parser didn't find the section)
- Replacing the pipe table with plain text (no data to parse)

This restores the `## Plugins` heading and the three-column pipe table with GDPR, Comments, and Artist Portfolio entries.

## CHANGELOG
- **README**: restore community plugin table for admin panel plugin discovery

## Test plan
- [ ] Open Admin → Plugins — Community Plugins section should show GDPR, Comments, Artist Portfolio