### PR TITLE
fix(blog): add unique validation on translation slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `blogr` will be documented in this file.
 
 ### 🐛 Fixed
 
+- **Blog posts**: slug duplicate validation now shows a validation error instead of a 500 error (#258)
 - **CMS**: deleting a block now requires confirmation to prevent accidental removals (#254)
 
 ## [v1.23.0](https://github.com/happytodev/blogr/compare/v1.22.0...v1.23.0) - 2026-07-01

--- a/src/Filament/Resources/BlogPosts/BlogPostForm.php
+++ b/src/Filament/Resources/BlogPosts/BlogPostForm.php
@@ -67,6 +67,7 @@ class BlogPostForm
                                 TextInput::make('slug')
                                     ->label('Slug')
                                     ->required()
+                                    ->unique(ignoreRecord: true)
                                     ->maxLength(255)
                                     ->helperText('URL-friendly version of the title')
                                     ->columnSpan(2),

--- a/tests/Feature/Filament/BlogPostSlugUniqueTest.php
+++ b/tests/Feature/Filament/BlogPostSlugUniqueTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Happytodev\Blogr\Filament\Resources\BlogPostResource\Pages\CreateBlogPost;
+use Happytodev\Blogr\Models\BlogPost;
+use Happytodev\Blogr\Models\Category;
+use Happytodev\Blogr\Models\User;
+use Happytodev\Blogr\Tests\CmsTestCase;
+use Illuminate\Support\ViewErrorBag;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+
+uses(CmsTestCase::class);
+
+beforeEach(function () {
+    Role::create(['name' => 'admin', 'guard_name' => 'web']);
+
+    $admin = User::factory()->create();
+    $admin->assignRole('admin');
+    $this->actingAs($admin);
+
+    $this->session(['errors' => new ViewErrorBag]);
+
+    Category::factory()->create();
+});
+
+test('regression_258_slug_unique_validation', function () {
+    $categoryId = Category::first()->id;
+
+    // Create an existing post with a specific slug
+    BlogPost::create([
+        'default_locale' => 'en',
+        'user_id' => auth()->id(),
+        'category_id' => $categoryId,
+        'title' => 'Existing Post',
+        'slug' => 'existing-slug',
+        'content' => 'Existing content',
+    ]);
+
+    // Try to create a new post with the same slug via the Filament form
+    Livewire::test(CreateBlogPost::class)
+        ->fillForm([
+            'translations' => [
+                [
+                    'locale' => 'en',
+                    'title' => 'New Post',
+                    'slug' => 'existing-slug',
+                    'content' => 'New content',
+                ],
+            ],
+            'category_id' => $categoryId,
+            'default_locale' => 'en',
+            'is_published' => false,
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['translations.0.slug' => 'unique']);
+});


### PR DESCRIPTION
## Summary
- Added `->unique(ignoreRecord: true)` to the slug field in the translations Repeater
- Previously, slug duplicates caused a 500 error (DB constraint violation)
- Now a user-friendly validation error is returned

## Test plan
- [x] `vendor/bin/pest --parallel` — 1310 passed
- [x] New regression test `regression_258_slug_unique_validation`
- [x] Anti-false-positive gate passed

Closes #258