### PR TITLE
fix(blog): prevent auto-save from publishing draft content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
-### 📝 Documentation
-
-- **README**: rewrite with current features, fix test count (1,266), remove obsolete roadmap and duplicate install instructions
+## [v1.23.1](https://github.com/happytodev/blogr/compare/v1.23.0...v1.23.1) - 2026-07-02
 
 ### 🐛 Fixed
 
 - **Blog posts**: slug duplicate validation now shows a validation error instead of a 500 error (#258)
 - **CMS**: deleting a block now requires confirmation to prevent accidental removals (#254)
+- **README**: restore community plugin table for admin panel parser
+
+### 📝 Documentation
+
+- **README**: rewrite with current features, fix test count (1,266), remove obsolete roadmap and duplicate install instructions
 
 ## [v1.23.0](https://github.com/happytodev/blogr/compare/v1.22.0...v1.23.0) - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **Blog posts**: auto-save no longer publishes draft content to the frontend (#260)
+- **Blog posts**: "Save & Publish" action now correctly sets the post as published (#260)
+
 ## [v1.23.1](https://github.com/happytodev/blogr/compare/v1.23.0...v1.23.1) - 2026-07-02
 
 ### 🐛 Fixed

--- a/src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
+++ b/src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
@@ -100,6 +100,13 @@ class EditBlogPost extends EditRecord
     {
         $data = $this->data ?? [];
 
+        $data = $this->mutateFormDataBeforeSave($data);
+        $data['is_published'] = true;
+
+        /** @var BlogPost $record */
+        $record = $this->record;
+        $record->update($data);
+
         app(VersioningService::class)->savePostDraft($this->record, $data);
         app(VersioningService::class)->publishPostDraft($this->record, $data['translations'] ?? []);
 

--- a/src/Traits/AutoSave.php
+++ b/src/Traits/AutoSave.php
@@ -82,12 +82,7 @@ trait AutoSave
 
             if ($record && $record->exists) {
                 if ($record instanceof BlogPost) {
-                    if ($record->is_published) {
-                        $draft = app(VersioningService::class)->savePostDraft($record, $currentState);
-                    } else {
-                        app(VersioningService::class)->savePostDraft($record, $currentState);
-                        app(VersioningService::class)->publishPostDraft($record, $currentState['translations'] ?? []);
-                    }
+                    app(VersioningService::class)->savePostDraft($record, $currentState);
                 } elseif ($record instanceof BlogPostTranslation) {
                     if ($record->post?->is_published) {
                         app(VersioningService::class)->saveDraft($record, $currentState);


### PR DESCRIPTION
## Summary
- Auto-save no longer publishes draft content to the frontend
- "Save & Publish" action now correctly sets `is_published = true` on the BlogPost model

## Fixes
- AutoSave::autoSave() called publishPostDraft() for draft BlogPosts
- saveAndPublish() didn't save BlogPost model data or set is_published

## Test plan
- [x] `vendor/bin/pest --parallel` — 1310 passed
- [x] Full suite passes with no regressions

Closes #260