### PR TITLE
feat(blog): improve Save Draft, add Unpublish action and unpublish_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **Blog posts**: "Save Draft" now correctly persists the `is_published` toggle (#262)
+- **Blog posts**: "Unpublish" action added with confirmation modal (#262)
+
+### ✨ Added
+
+- **Blog posts**: `unpublish_at` field for scheduled automatic unpublishing (#262)
+- **Command**: `blogr:check-unpublish` Artisan command to auto-unpublish posts (#262)
+
 ## [v1.23.2](https://github.com/happytodev/blogr/compare/v1.23.1...v1.23.2) - 2026-07-02
 
 ### 🐛 Fixed

--- a/database/migrations/2026_06_17_000001_add_unpublish_at_to_blog_posts.php
+++ b/database/migrations/2026_06_17_000001_add_unpublish_at_to_blog_posts.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('blog_posts', function (Blueprint $table) {
+            $table->timestamp('unpublish_at')->nullable()->after('published_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('blog_posts', function (Blueprint $table) {
+            $table->dropColumn('unpublish_at');
+        });
+    }
+};

--- a/src/BlogrServiceProvider.php
+++ b/src/BlogrServiceProvider.php
@@ -8,6 +8,7 @@ use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentIcon;
+use Happytodev\Blogr\Commands\BlogrCheckUnpublishCommand;
 use Happytodev\Blogr\Commands\BlogrCommand;
 use Happytodev\Blogr\Commands\BlogrExportCommand;
 use Happytodev\Blogr\Commands\BlogrImportCommand;
@@ -92,6 +93,7 @@ class BlogrServiceProvider extends PackageServiceProvider
         // Register commands
         $package->hasCommands([
             BlogrCommand::class,
+            BlogrCheckUnpublishCommand::class,
             BlogrInstallCommand::class,
             SyncAdminPathCommand::class,
             InstallBreezyCommand::class,
@@ -314,6 +316,10 @@ class BlogrServiceProvider extends PackageServiceProvider
             foreach ($extensionRegistry->getEnabled() as $extension) {
                 $extension->registerLinkTypes($linkTypeRegistry);
             }
+        });
+
+        $this->callAfterResolving('orchestra.schedule', function ($schedule) {
+            $schedule->command('blogr:check-unpublish')->everyMinute();
         });
     }
 
@@ -929,6 +935,7 @@ class BlogrServiceProvider extends PackageServiceProvider
             '2026_06_13_000001_add_avatar_url_to_users_table',
             '2026_06_16_000001_create_blog_post_drafts_table',
             '2026_06_16_000002_create_blog_post_versions_table',
+            '2026_06_17_000001_add_unpublish_at_to_blog_posts',
         ];
 
         // Add CMS migrations if CMS is enabled

--- a/src/Commands/BlogrCheckUnpublishCommand.php
+++ b/src/Commands/BlogrCheckUnpublishCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Happytodev\Blogr\Commands;
+
+use Happytodev\Blogr\Models\BlogPost;
+use Illuminate\Console\Command;
+
+class BlogrCheckUnpublishCommand extends Command
+{
+    public $signature = 'blogr:check-unpublish';
+
+    public $description = 'Unpublish posts whose unpublish_at date has passed';
+
+    public function handle(): int
+    {
+        $count = BlogPost::query()
+            ->where('is_published', true)
+            ->whereNotNull('unpublish_at')
+            ->where('unpublish_at', '<=', now())
+            ->update([
+                'is_published' => false,
+                'published_at' => null,
+                'unpublish_at' => null,
+            ]);
+
+        if ($count > 0) {
+            $this->info("Unpublished {$count} post(s) whose unpublish_at date has passed.");
+        } else {
+            $this->info('No posts to unpublish.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
+++ b/src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
@@ -68,11 +68,22 @@ class EditBlogPost extends EditRecord
                     $this->saveAndPublish();
                 }),
             Actions\Action::make('saveAsDraft')
-                ->label('Save as Draft')
+                ->label('Save Draft')
                 ->icon('heroicon-o-cloud-arrow-up')
                 ->color('gray')
                 ->action(function () {
                     $this->saveAsDraft();
+                }),
+            Actions\Action::make('unpublish')
+                ->label('Unpublish')
+                ->icon('heroicon-o-arrow-uturn-down')
+                ->color('danger')
+                ->visible(fn () => $this->record && $this->record->is_published)
+                ->requiresConfirmation()
+                ->modalHeading('Unpublish post')
+                ->modalDescription('This will unpublish the post immediately. It will no longer be visible on the frontend.')
+                ->action(function () {
+                    $this->unpublish();
                 }),
             $this->getCancelFormAction(),
         ];
@@ -81,6 +92,13 @@ class EditBlogPost extends EditRecord
     protected function saveAsDraft(): void
     {
         $data = $this->data ?? [];
+
+        $data = $this->mutateFormDataBeforeSave($data);
+
+        /** @var BlogPost $record */
+        $record = $this->record;
+        $record->update($data);
+
         app(VersioningService::class)->savePostDraft($this->record, $data);
 
         $this->lastAutoSaveAt = now()->toIso8601String();
@@ -90,8 +108,28 @@ class EditBlogPost extends EditRecord
         $this->record->load('translations');
         $this->fillForm();
 
+        $label = $record->is_published ? 'Draft saved' : 'Draft saved successfully';
+
         Notification::make()
-            ->title('Draft saved successfully')
+            ->title($label)
+            ->success()
+            ->send();
+    }
+
+    protected function unpublish(): void
+    {
+        /** @var BlogPost $record */
+        $record = $this->record;
+        $record->update([
+            'is_published' => false,
+            'published_at' => null,
+        ]);
+
+        $this->record->load('translations');
+        $this->fillForm();
+
+        Notification::make()
+            ->title('Post unpublished successfully')
             ->success()
             ->send();
     }

--- a/src/Filament/Resources/BlogPosts/BlogPostForm.php
+++ b/src/Filament/Resources/BlogPosts/BlogPostForm.php
@@ -436,6 +436,13 @@ class BlogPostForm
                             ->visible(fn () => Filament::auth()->user() && method_exists(Filament::auth()->user(), 'hasRole') ? Filament::auth()->user()->hasRole('admin') : false)
                             ->helperText('Leave empty for immediate publication, or set a future date to schedule publication.'),
 
+                        DateTimePicker::make('unpublish_at')
+                            ->label('Unpublish Date')
+                            ->nullable()
+                            ->live()
+                            ->visible(fn () => Filament::auth()->user() && method_exists(Filament::auth()->user(), 'hasRole') ? Filament::auth()->user()->hasRole('admin') : false)
+                            ->helperText('Set a date and time after which the post will no longer be visible on the frontend.'),
+
                         Select::make('default_locale')
                             ->label('Default Language')
                             ->options(function () {

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -56,11 +56,7 @@ class BlogController
                 'translations', // Load all translations for photo fallback
             ])
             ->orderBy('published_at', 'desc')
-            ->where('is_published', true)
-            ->where(function ($query) {
-                $query->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            })
+            ->published()
             ->visibleOnIndex()
             ->paginate(config('blogr.posts_per_page', 10))
             ->through(function ($post) use ($locale) {
@@ -215,6 +211,10 @@ class BlogController
         }
 
         if ($post->published_at && $post->published_at->isFuture()) {
+            abort(404);
+        }
+
+        if ($post->unpublish_at && $post->unpublish_at->isPast()) {
             abort(404);
         }
 
@@ -531,11 +531,7 @@ class BlogController
             },
         ])
             ->where('category_id', $category->id)
-            ->where('is_published', true)
-            ->where(function ($query) {
-                $query->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            })
+            ->published()
             ->visibleOnIndex()
             ->orderBy('published_at', 'desc')
             ->paginate(config('blogr.posts_per_page', 10))
@@ -630,11 +626,7 @@ class BlogController
                     $query->where('locale', $currentLocale);
                 },
             ])
-            ->where('is_published', true)
-            ->where(function ($query) {
-                $query->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            })
+            ->published()
             ->visibleOnIndex()
             ->orderBy('published_at', 'desc')
             ->take(config('blogr.posts_per_page', 10))

--- a/src/Models/BlogPost.php
+++ b/src/Models/BlogPost.php
@@ -25,6 +25,7 @@ class BlogPost extends Model
         'is_published',
         'is_listed',
         'published_at',
+        'unpublish_at',
         'category_id',
         'blog_series_id',
         'series_position',
@@ -42,6 +43,7 @@ class BlogPost extends Model
 
     protected $casts = [
         'published_at' => 'datetime',
+        'unpublish_at' => 'datetime',
         'is_published' => 'boolean',
         'is_listed' => 'boolean',
         'display_toc' => 'boolean',
@@ -159,7 +161,19 @@ class BlogPost extends Model
     // Check if the post is currently published (either immediate or scheduled time reached)
     public function isCurrentlyPublished()
     {
-        return $this->is_published && (! $this->published_at || $this->published_at->isPast());
+        if (! $this->is_published) {
+            return false;
+        }
+
+        if ($this->published_at && $this->published_at->isFuture()) {
+            return false;
+        }
+
+        if ($this->unpublish_at && $this->unpublish_at->isPast()) {
+            return false;
+        }
+
+        return true;
     }
 
     // Scope: published posts only
@@ -168,6 +182,9 @@ class BlogPost extends Model
         return $query->where('is_published', true)
             ->where(function ($q) {
                 $q->whereNull('published_at')->orWhere('published_at', '<=', now());
+            })
+            ->where(function ($q) {
+                $q->whereNull('unpublish_at')->orWhere('unpublish_at', '>', now());
             });
     }
 
@@ -185,6 +202,10 @@ class BlogPost extends Model
     public function getPublicationStatus()
     {
         if (! $this->is_published) {
+            return 'draft';
+        }
+
+        if ($this->unpublish_at && $this->unpublish_at->isPast()) {
             return 'draft';
         }
 

--- a/tests/Feature/Filament/SaveDraftPublishTest.php
+++ b/tests/Feature/Filament/SaveDraftPublishTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Happytodev\Blogr\Filament\Resources\BlogPostResource\Pages\EditBlogPost;
+use Happytodev\Blogr\Models\BlogPost;
+use Happytodev\Blogr\Models\Category;
+use Happytodev\Blogr\Models\User;
+use Happytodev\Blogr\Services\VersioningService;
+use Happytodev\Blogr\Tests\CmsTestCase;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+
+uses(CmsTestCase::class);
+
+beforeEach(function () {
+    Role::create(['name' => 'admin', 'guard_name' => 'web']);
+
+    $admin = User::factory()->create();
+    $admin->assignRole('admin');
+    $this->actingAs($admin);
+
+    $category = Category::factory()->create();
+
+    $this->post = BlogPost::factory()->create([
+        'user_id' => $admin->id,
+        'category_id' => $category->id,
+        'is_published' => true,
+        'published_at' => now(),
+        'title' => 'Published Post',
+        'slug' => 'published-post',
+        'content' => 'Content',
+    ]);
+});
+
+test('regression_262_save_as_draft_preserves_is_published_toggle', function () {
+    // Toggle is_published to false via Livewire and click "Save Draft"
+    $component = Livewire::test(EditBlogPost::class, ['record' => $this->post->id]);
+    $component->set('data.is_published', false);
+    $component->set('data.published_at', null);
+
+    $reflection = new ReflectionMethod(EditBlogPost::class, 'saveAsDraft');
+    $reflection->setAccessible(true);
+    $reflection->invoke($component->instance());
+
+    $component->assertSet('data.is_published', false);
+
+    // The post should now be unpublished in the database
+    $this->post->refresh();
+    expect($this->post->is_published)->toBeFalse();
+});
+
+test('regression_262_save_as_draft_on_published_keeps_published', function () {
+    // Click "Save Draft" without changing is_published
+    $component = Livewire::test(EditBlogPost::class, ['record' => $this->post->id]);
+
+    $reflection = new ReflectionMethod(EditBlogPost::class, 'saveAsDraft');
+    $reflection->setAccessible(true);
+    $reflection->invoke($component->instance());
+
+    $component->assertSet('data.is_published', true);
+
+    // The post should remain published
+    $this->post->refresh();
+    expect($this->post->is_published)->toBeTrue();
+});

--- a/tests/Feature/VersioningTest.php
+++ b/tests/Feature/VersioningTest.php
@@ -159,7 +159,7 @@ it('publishes post via VersioningService', function () {
     expect($this->translation->title)->toBe('Published Title');
 });
 
-// ── Save as Draft ──
+// ── Save Draft ──
 
 it('save as draft keeps live translation unchanged', function () {
     app(VersioningService::class)->savePostDraft($this->post, [
@@ -245,12 +245,12 @@ it('stores all text fields in version', function () {
         ->and($version->seo_keywords)->toBe('kw1, kw2');
 });
 
-it('has form actions for Save & Publish, Save as Draft, Cancel', function () {
+it('has form actions for Save & Publish, Save Draft, Cancel', function () {
     Livewire::test(EditBlogPost::class, [
         'record' => $this->post->id,
     ])
         ->assertSee('Save & Publish')
-        ->assertSee('Save as Draft');
+        ->assertSee('Save Draft');
 });
 
 it('has history action in header', function () {


### PR DESCRIPTION
## Summary

### Bug fixes
- **Save Draft** now correctly persists the `is_published` toggle, allowing users to unpublish a post by toggling and clicking "Save Draft"
- Renamed "Save as Draft" to "Save Draft" for clarity

### New features
- **Unpublish action** added to the form with confirmation modal (visible only on published posts)
- **`unpublish_at`** datetime field in Publication Settings — set a date after which the post is automatically unpublished
- **`blogr:check-unpublish`** Artisan command (runs every minute via scheduler)

### Infrastructure
- `scopePublished()` now respects `unpublish_at`
- Frontend controller (index, show, category, tag, series) checks `unpublish_at`
- New database migration `2026_06_17_000001_add_unpublish_at_to_blog_posts`

## Test plan
- [x] `vendor/bin/pest --parallel` — 1312 passed (3852 assertions)
- [x] New regression test: `regression_262_save_as_draft_preserves_is_published_toggle`
- [x] New regression test: `regression_262_save_as_draft_on_published_keeps_published`

Closes #262