### PR TITLE
fix(blog): detect and display photo changes in post history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **Blog posts**: photo changes are now detected and displayed in the version history (#269)
+
 ## [v1.23.10](https://github.com/happytodev/blogr/compare/v1.23.9...v1.23.10) - 2026-07-03
 
 ### 🐛 Fixed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,7 +61,7 @@ parameters:
 			path: src/BlogrServiceProvider.php
 
 		-
-			message: '#^Method Happytodev\\Blogr\\Contracts\\BlogrExtension@anonymous/BlogrServiceProvider\.php\:398\:\:getDependencies\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Happytodev\\Blogr\\Contracts\\BlogrExtension@anonymous/BlogrServiceProvider\.php\:404\:\:getDependencies\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/BlogrServiceProvider.php
@@ -3211,12 +3211,6 @@ parameters:
 			path: src/Filament/Resources/BlogPostResource.php
 
 		-
-			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPost\:\:\$is_published\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
-
-		-
 			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPost\:\:\$translations\.$#'
 			identifier: property.notFound
 			count: 1
@@ -3295,6 +3289,18 @@ parameters:
 			path: src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
 
 		-
+			message: '#^Method Happytodev\\Blogr\\Filament\\Resources\\BlogPostResource\\Pages\\CreateBlogPost\:\:normalizePhotoForCreate\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
+
+		-
+			message: '#^Method Happytodev\\Blogr\\Filament\\Resources\\BlogPostResource\\Pages\\CreateBlogPost\:\:normalizePhotoForCreate\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
+
+		-
 			message: '#^Method Happytodev\\Blogr\\Filament\\Resources\\BlogPostResource\\Pages\\CreateBlogPost\:\:sanitizeForSnapshot\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3313,6 +3319,12 @@ parameters:
 			path: src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
 
 		-
+			message: '#^Parameter \#1 \$data of method Happytodev\\Blogr\\Filament\\Resources\\BlogPostResource\\Pages\\CreateBlogPost\:\:normalizePhotoForCreate\(\) expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
+
+		-
 			message: '#^Parameter \#1 \$post of method Happytodev\\Blogr\\Services\\VersioningService\:\:getPostDraft\(\) expects Happytodev\\Blogr\\Models\\BlogPost, Illuminate\\Database\\Eloquent\\Model given\.$#'
 			identifier: argument.type
 			count: 1
@@ -3326,12 +3338,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$view of static method Filament\\Schemas\\Components\\View\:\:make\(\) expects view\-string, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
-
-		-
-			message: '#^Parameter \#2 \$translationsData of method Happytodev\\Blogr\\Services\\VersioningService\:\:publishPostDraft\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
@@ -3411,7 +3417,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''locale'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 2
 			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
 
 		-
@@ -3463,6 +3469,12 @@ parameters:
 			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
 
 		-
+			message: '#^Cannot access property \$is_published on Illuminate\\Database\\Eloquent\\Model\|int\<min, \-1\>\|int\<1, max\>\|string\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
+
+		-
 			message: '#^Cannot access property \$is_published on Illuminate\\Database\\Eloquent\\Model\|int\|string\|null\.$#'
 			identifier: property.nonObject
 			count: 1
@@ -3489,7 +3501,7 @@ parameters:
 		-
 			message: '#^Cannot call method load\(\) on Illuminate\\Database\\Eloquent\\Model\|int\|string\|null\.$#'
 			identifier: method.nonObject
-			count: 5
+			count: 7
 			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
 
 		-
@@ -3523,6 +3535,18 @@ parameters:
 			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
 
 		-
+			message: '#^Method Happytodev\\Blogr\\Filament\\Resources\\BlogPostResource\\Pages\\EditBlogPost\:\:normalizePhotoField\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
+
+		-
+			message: '#^Method Happytodev\\Blogr\\Filament\\Resources\\BlogPostResource\\Pages\\EditBlogPost\:\:normalizePhotoField\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
+
+		-
 			message: '#^Method Happytodev\\Blogr\\Filament\\Resources\\BlogPostResource\\Pages\\EditBlogPost\:\:sanitizeForSnapshot\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3547,6 +3571,12 @@ parameters:
 			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
 
 		-
+			message: '#^Parameter \#1 \$data of static method Happytodev\\Blogr\\Filament\\Resources\\BlogPostResource\\Pages\\EditBlogPost\:\:normalizePhotoField\(\) expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
+
+		-
 			message: '#^Parameter \#1 \$options of method Filament\\Forms\\Components\\Select\:\:options\(\) expects array\<array\<string\>\|string\>\|Closure\|Illuminate\\Contracts\\Support\\Arrayable\|string\|null, array\<mixed\> given\.$#'
 			identifier: argument.type
 			count: 2
@@ -3561,13 +3591,13 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$post of method Happytodev\\Blogr\\Services\\VersioningService\:\:publishPostDraft\(\) expects Happytodev\\Blogr\\Models\\BlogPost, Illuminate\\Database\\Eloquent\\Model\|int\|string\|null given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
 
 		-
 			message: '#^Parameter \#1 \$post of method Happytodev\\Blogr\\Services\\VersioningService\:\:savePostDraft\(\) expects Happytodev\\Blogr\\Models\\BlogPost, Illuminate\\Database\\Eloquent\\Model\|int\|string\|null given\.$#'
 			identifier: argument.type
-			count: 3
+			count: 4
 			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
 
 		-
@@ -3609,6 +3639,18 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$translationsData of method Happytodev\\Blogr\\Services\\VersioningService\:\:publishPostDraft\(\) expects array, mixed given\.$#'
 			identifier: argument.type
+			count: 1
+			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
+
+		-
+			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
+
+		-
+			message: '#^Possibly invalid array key type mixed\.$#'
+			identifier: offsetAccess.invalidOffset
 			count: 2
 			path: src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
 
@@ -3735,7 +3777,7 @@ parameters:
 		-
 			message: '#^Call to function method_exists\(\) with Workbench\\App\\Models\\User and ''hasRole'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 4
+			count: 5
 			path: src/Filament/Resources/BlogPosts/BlogPostForm.php
 
 		-
@@ -3941,12 +3983,6 @@ parameters:
 			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: src/Filament/Resources/CmsPageResource/Pages/EditCmsPage.php
-
-		-
-			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPost\:\:\$is_published\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Filament/Resources/CmsPageResource/Pages/EditCmsPageTranslation.php
 
 		-
 			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPostDraft\:\:\$updated_at\.$#'
@@ -4232,12 +4268,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$view of static method Filament\\Schemas\\Components\\View\:\:make\(\) expects view\-string, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Filament/Resources/CmsPageResource/Pages/EditCmsPageTranslation.php
-
-		-
-			message: '#^Parameter \#2 \$translationsData of method Happytodev\\Blogr\\Services\\VersioningService\:\:publishPostDraft\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Filament/Resources/CmsPageResource/Pages/EditCmsPageTranslation.php
@@ -5119,6 +5149,12 @@ parameters:
 			path: src/Http/Controllers/BlogController.php
 
 		-
+			message: '#^Cannot access property \$unpublish_at on Illuminate\\Database\\Eloquent\\Model\|null\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/Http/Controllers/BlogController.php
+
+		-
 			message: '#^Cannot access property \$updated_at on Illuminate\\Database\\Eloquent\\Model\|null\.$#'
 			identifier: property.nonObject
 			count: 2
@@ -5888,6 +5924,12 @@ parameters:
 
 		-
 			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPost\:\:\$translations\.$#'
+			identifier: property.notFound
+			count: 2
+			path: src/Models/BlogPost.php
+
+		-
+			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPost\:\:\$unpublish_at\.$#'
 			identifier: property.notFound
 			count: 2
 			path: src/Models/BlogPost.php

--- a/resources/views/components/version-history.blade.php
+++ b/resources/views/components/version-history.blade.php
@@ -26,9 +26,10 @@
                                             'content' => 'Content', 'tldr' => 'TL;DR',
                                             'blocks' => 'Blocks',
                                             'seo_title' => 'SEO Title', 'seo_description' => 'SEO Desc',
-                                            'seo_keywords' => 'SEO Keywords',
-                                        ];
-                                    @endphp
+                                        'seo_keywords' => 'SEO Keywords',
+                                        'photo' => 'Cover Image',
+                                    ];
+                                @endphp
                                     <span class="text-xs px-1.5 py-0.5 rounded-full bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 font-medium">
                                         {{ $labels[$field] ?? $field }}
                                     </span>
@@ -64,6 +65,7 @@
                             'seo_title' => 'SEO Title',
                             'seo_description' => 'SEO Description',
                             'seo_keywords' => 'SEO Keywords',
+                        'photo' => 'Cover Image',
                         ];
                     @endphp
 
@@ -144,9 +146,10 @@
                                             'content' => 'Content', 'tldr' => 'TL;DR',
                                             'blocks' => 'Blocks',
                                             'seo_title' => 'SEO Title', 'seo_description' => 'SEO Desc',
-                                            'seo_keywords' => 'SEO Keywords',
-                                        ];
-                                    @endphp
+                                        'seo_keywords' => 'SEO Keywords',
+                                        'photo' => 'Cover Image',
+                                    ];
+                                @endphp
                                     <span class="text-xs px-1.5 py-0.5 rounded-full bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 font-medium">
                                         {{ $labels[$field] ?? $field }}
                                     </span>
@@ -188,6 +191,7 @@
                             'seo_title' => 'SEO Title',
                             'seo_description' => 'SEO Description',
                             'seo_keywords' => 'SEO Keywords',
+                        'photo' => 'Cover Image',
                         ];
                     @endphp
 

--- a/src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
+++ b/src/Filament/Resources/BlogPostResource/Pages/CreateBlogPost.php
@@ -104,6 +104,7 @@ class CreateBlogPost extends CreateRecord
             } catch (\Throwable) {
                 unset($data[$field]);
             }
+
             return $data;
         }
 

--- a/src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
+++ b/src/Filament/Resources/BlogPostResource/Pages/EditBlogPost.php
@@ -304,7 +304,7 @@ class EditBlogPost extends EditRecord
                 $draftEntry = null;
                 if ($draft && isset($draft->draft_data['translations'])) {
                     $draftTranslations = $draft->draft_data['translations'];
-                    $fieldKeys = ['title', 'slug', 'tldr', 'content', 'seo_title', 'seo_description', 'seo_keywords'];
+                    $fieldKeys = ['title', 'slug', 'tldr', 'content', 'seo_title', 'seo_description', 'seo_keywords', 'photo'];
                     $perLocaleFields = [];
                     $perLocalePrevious = [];
                     $allChanges = [];
@@ -361,11 +361,11 @@ class EditBlogPost extends EditRecord
                     foreach ($translationVersions->sortBy('version_number') as $v) {
                         $currentFields = $v->only([
                             'title', 'slug', 'tldr', 'content',
-                            'seo_title', 'seo_description', 'seo_keywords',
+                            'seo_title', 'seo_description', 'seo_keywords', 'photo',
                         ]);
                         $previousFields = $prevVersion ? $prevVersion->only([
                             'title', 'slug', 'tldr', 'content',
-                            'seo_title', 'seo_description', 'seo_keywords',
+                            'seo_title', 'seo_description', 'seo_keywords', 'photo',
                         ]) : [];
                         $changes = $prevVersion
                             ? array_keys(array_diff_assoc($currentFields, $previousFields))
@@ -523,6 +523,7 @@ class EditBlogPost extends EditRecord
             } catch (\Throwable) {
                 unset($data[$field]);
             }
+
             return $data;
         }
 

--- a/tests/Feature/VersioningTest.php
+++ b/tests/Feature/VersioningTest.php
@@ -323,3 +323,63 @@ it('does not create a version when publishing identical content', function () {
     $versions = CmsPageVersion::where('cms_page_translation_id', $translation->id)->get();
     expect($versions)->toHaveCount(1);
 });
+
+it('regression_269_history_shows_photo_changes', function () {
+    // Create two versions with different photos
+    BlogPostVersion::create([
+        'blog_post_translation_id' => $this->translation->id,
+        'version_number' => 1,
+        'title' => 'v1',
+        'photo' => 'blog-photos/old.jpg',
+    ]);
+    BlogPostVersion::create([
+        'blog_post_translation_id' => $this->translation->id,
+        'version_number' => 2,
+        'title' => 'v2',
+        'photo' => 'blog-photos/new.jpg',
+    ]);
+
+    // Render the version-history component directly with the same data
+    // structure that EditBlogPost's history action builds.
+    $versions = BlogPostVersion::where('blog_post_translation_id', $this->translation->id)
+        ->orderBy('version_number')
+        ->get();
+
+    $history = collect();
+    $prevVersion = null;
+    foreach ($versions as $v) {
+        $currentFields = $v->only([
+            'title', 'slug', 'tldr', 'content',
+            'seo_title', 'seo_description', 'seo_keywords', 'photo',
+        ]);
+        $previousFields = $prevVersion ? $prevVersion->only([
+            'title', 'slug', 'tldr', 'content',
+            'seo_title', 'seo_description', 'seo_keywords', 'photo',
+        ]) : [];
+        $changes = $prevVersion
+            ? array_keys(array_diff_assoc($currentFields, $previousFields))
+            : ['initial'];
+
+        $history->push([
+            'type' => 'version',
+            'title' => $v->title,
+            'version_number' => $v->version_number,
+            'version_id' => $v->id,
+            'translation_id' => $v->blog_post_translation_id,
+            'locale' => $this->translation->locale,
+            'created_at' => $v->created_at,
+            'fields' => $currentFields,
+            'previous_fields' => $prevVersion ? $previousFields : null,
+            'changes' => $changes,
+        ]);
+        $prevVersion = $v;
+    }
+
+    $html = view('blogr::components.version-history', [
+        'history' => $history,
+    ])->render();
+
+    expect($html)
+        ->toContain('blog-photos/old.jpg')
+        ->toContain('Cover Image');
+});


### PR DESCRIPTION
## Summary

Photo changes in blog post history were not detected or displayed — the History modal showed empty diffs when only the cover image changed.

### Root cause

The `photo` field was missing from:
- The version field comparison lists in `EditBlogPost.php` (draft vs last version, and version-to-version)
- The label/diff label arrays in `version-history.blade.php`

### Fix

- Added `'photo'` to the draft field keys and version `only()` arrays in `EditBlogPost.php`
- Added `'photo' => 'Cover Image'` to all four label/diff arrays in `version-history.blade.php`
- Also regenerated `phpstan-baseline.neon` (pre-existing ignore pattern counts were stale)

## Regression test

`regression_269_history_shows_photo_changes` — creates two versions with different photos, renders the version-history component, and asserts the old photo path and "Cover Image" label appear in the diff.

## Test plan

- [ ] `vendor/bin/pest --parallel`
- [ ] Open History modal on a post with photo changes — "Cover Image" should appear in the diff

Closes #269