### PR TITLE
fix(admin): filter out non-existent widget classes in panel registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `blogr` will be documented in this file.
 ### 🐛 Fixed
 
 - **Blog posts**: photo changes are now detected and displayed in the version history (#269)
+- **Dashboard**: prevent crash when `dashboard_widgets` config references a removed widget class (`QuickVisitSite`) — non-existent classes are now silently filtered out (#271)
 
 ## [v1.23.10](https://github.com/happytodev/blogr/compare/v1.23.9...v1.23.10) - 2026-07-03
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -145,12 +145,6 @@ parameters:
 			path: src/BlogrWidgets.php
 
 		-
-			message: '#^Parameter \#2 \.\.\.\$arrays of function array_intersect expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/BlogrWidgets.php
-
-		-
 			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPost\:\:\$is_published\.$#'
 			identifier: property.notFound
 			count: 1

--- a/src/BlogrPlugin.php
+++ b/src/BlogrPlugin.php
@@ -42,7 +42,13 @@ class BlogrPlugin implements Plugin
             Plugins::class,
         ]);
 
-        $widgets = BlogrWidgets::enabled();
+        $widgets = array_values(array_intersect(
+            BlogrWidgets::enabled(),
+            array_filter(
+                BlogrWidgets::all(),
+                fn (string $class): bool => class_exists($class),
+            ),
+        ));
 
         if (config('blogr.cms.enabled', false)) {
             $widgets[] = CmsStatsOverview::class;

--- a/src/BlogrWidgets.php
+++ b/src/BlogrWidgets.php
@@ -76,16 +76,19 @@ class BlogrWidgets
     }
 
     /**
-     * Get enabled widgets based on config
+     * Get enabled widgets based on config (raw, unfiltered)
      */
     public static function enabled(): array
     {
         $enabled = config('blogr.dashboard_widgets', []);
 
-        if (empty($enabled)) {
+        if (! is_array($enabled) || empty($enabled)) {
             return self::core();
         }
 
-        return array_intersect(self::all(), $enabled);
+        return array_values(array_filter(
+            $enabled,
+            fn ($class): bool => is_string($class),
+        ));
     }
 }

--- a/tests/Feature/Regression271StaleWidgetConfigTest.php
+++ b/tests/Feature/Regression271StaleWidgetConfigTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Filament\Panel;
+use Happytodev\Blogr\BlogrPlugin;
+use Happytodev\Blogr\BlogrWidgets;
+use Happytodev\Blogr\Tests\TestCase;
+
+uses(TestCase::class);
+
+it('returns raw config from enabled() including stale widget classes', function () {
+    config()->set('blogr.dashboard_widgets', [
+        'Happytodev\Blogr\Filament\Widgets\QuickVisitSite',
+        'Happytodev\Blogr\Filament\Widgets\BlogStatsOverview',
+    ]);
+
+    $enabled = BlogrWidgets::enabled();
+
+    expect($enabled)->toContain('Happytodev\Blogr\Filament\Widgets\QuickVisitSite');
+    expect($enabled)->toContain('Happytodev\Blogr\Filament\Widgets\BlogStatsOverview');
+});
+
+it('does not crash when registering with stale widget config', function () {
+    config()->set('blogr.dashboard_widgets', [
+        'Happytodev\Blogr\Filament\Widgets\QuickVisitSite',
+    ]);
+
+    $panel = Panel::make();
+    $plugin = BlogrPlugin::make();
+
+    $plugin->register($panel);
+
+    $widgets = $panel->getWidgets();
+
+    expect($widgets)->not->toContain('Happytodev\Blogr\Filament\Widgets\QuickVisitSite');
+});
+
+it('falls back to core widgets when dashboard_widgets config is empty', function () {
+    config()->set('blogr.dashboard_widgets', []);
+
+    $enabled = BlogrWidgets::enabled();
+
+    expect($enabled)->toBe(BlogrWidgets::core());
+});


### PR DESCRIPTION
## Summary

When the `dashboard_widgets` config contains a widget class that no longer exists (e.g. `QuickVisitSite` removed in v1.22), the Dashboard page crashes with `Class not found` / `ComponentNotFoundException`.

The root cause: the old config reference bypasses validation and Filament's `getWidgets()` tries to call `::getSort()` on the non-existent class.

### Fix

- **`BlogrPlugin::register()`** now filters the widget list with `array_intersect(BlogrWidgets::all(), ...)` + `class_exists()` before passing to `$panel->widgets()`
- **`BlogrWidgets::enabled()`** simplified to return raw config (validation centralized in the plugin)
- **`phpstan-baseline.neon`** — removed stale ignore entry for the old `array_intersect` pattern

### Test plan

- [x] `vendor/bin/pest --parallel` — 1330 passed, 0 failures
- [x] New regression test `tests/Feature/Regression271StaleWidgetConfigTest.php` (RED→GREEN→anti-false-positive verified)

## CHANGELOG

- **Dashboard**: prevent crash when `dashboard_widgets` config references a removed widget class (`QuickVisitSite`) — non-existent classes are now silently filtered out (#271)

## Related

- Closes #271