### PR TITLE
fix(blog): prevent UrlGenerationException on author page when posts have no translations (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **Author page**: posts without translations no longer cause UrlGenerationException on author profile page (#279)
+- **Blog post queries**: fixed N+1 SQL queries in `getDefaultTranslation()` when translations are eager-loaded (#279)
+
 ## [v1.23.17](https://github.com/happytodev/blogr/compare/v1.23.16...v1.23.17) - 2026-07-04
 
 ### 🐛 Fixed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4821,7 +4821,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPost\:\:\$translations\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 3
 			path: src/Http/Controllers/AuthorController.php
 
 		-
@@ -4856,6 +4856,12 @@ parameters:
 
 		-
 			message: '#^Relation ''category'' is not found in Happytodev\\Blogr\\Models\\BlogPost model\.$#'
+			identifier: larastan.relationExistence
+			count: 1
+			path: src/Http/Controllers/AuthorController.php
+
+		-
+			message: '#^Relation ''translations'' is not found in Happytodev\\Blogr\\Models\\BlogPost model\.$#'
 			identifier: larastan.relationExistence
 			count: 1
 			path: src/Http/Controllers/AuthorController.php
@@ -4905,7 +4911,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPost\:\:\$translations\.$#'
 			identifier: property.notFound
-			count: 4
+			count: 5
 			path: src/Http/Controllers/BlogController.php
 
 		-
@@ -5913,7 +5919,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Happytodev\\Blogr\\Models\\BlogPost\:\:\$translations\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 3
 			path: src/Models/BlogPost.php
 
 		-

--- a/resources/views/author/show.blade.php
+++ b/resources/views/author/show.blade.php
@@ -81,7 +81,7 @@
                     <article class="group bg-white dark:bg-gray-800 rounded-xl shadow-lg hover:shadow-2xl overflow-hidden transition-all duration-300 transform hover:-translate-y-1 flex flex-col h-full">
                         {{-- Post Image --}}
                         <div class="relative h-56 bg-gradient-to-br from-blue-500 to-purple-600 overflow-hidden">
-                            <a href="{{ route('blog.show', ['locale' => $currentLocale, 'slug' => $post->translated_slug]) }}" class="block h-full">
+                            <a href="{{ route('blog.show', ['locale' => $currentLocale, 'slug' => $post->translated_slug ?? $post->slug]) }}" class="block h-full">
                                 @if($post->photo_url ?? false)
                                     <img src="{{ $post->photo_url }}" 
                                          alt="{{ $post->translated_title }}" 
@@ -121,7 +121,7 @@
                         <div class="p-6 flex-grow flex flex-col">
                             {{-- Title --}}
                             <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">
-                                <a href="{{ route('blog.show', ['locale' => $currentLocale, 'slug' => $post->translated_slug]) }}"
+                                <a href="{{ route('blog.show', ['locale' => $currentLocale, 'slug' => $post->translated_slug ?? $post->slug]) }}"
                                    class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                                     {{ $post->translated_title }}
                                 </a>
@@ -169,7 +169,7 @@
                                     @endif
                                     
                                     {{-- Read More Link --}}
-                                    <a href="{{ route('blog.show', ['locale' => $currentLocale, 'slug' => $post->translated_slug]) }}" 
+                                    <a href="{{ route('blog.show', ['locale' => $currentLocale, 'slug' => $post->translated_slug ?? $post->slug]) }}" 
                                        class="text-blue-600 dark:text-blue-400 font-semibold hover:text-blue-800 dark:hover:text-blue-300 text-sm transition-colors">
                                         {{ __('Read more') }} →
                                     </a>

--- a/src/Http/Controllers/AuthorController.php
+++ b/src/Http/Controllers/AuthorController.php
@@ -47,6 +47,7 @@ class AuthorController extends Controller
             'translations',
             'user',
         ])
+            ->whereHas('translations')
             ->where('user_id', $author->id)
             ->where('is_published', true)
             ->whereNotNull('published_at')
@@ -64,7 +65,8 @@ class AuthorController extends Controller
 
                 // Override post attributes with translation, with fallback to model accessors
                 $post->translated_title = $translation?->title ?? $post->title;
-                $post->translated_slug = $translation?->slug ?? $post->slug;
+                $post->translated_slug = $translation?->slug
+                    ?? $post->translations->first(fn ($t) => ! empty($t->slug))?->slug;
                 $post->translated_tldr = $translation?->tldr ?? $post->tldr;
 
                 // Set reading time from translation (use stored value, don't recalculate)

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -70,7 +70,8 @@ class BlogController
 
                 // Override post attributes with translation, with fallback to model accessors
                 $post->translated_title = $translation?->title ?? $post->title;
-                $post->translated_slug = $translation?->slug ?? $post->slug;
+                $post->translated_slug = $translation?->slug
+                    ?? $post->translations->first(fn ($t) => ! empty($t->slug))?->slug;
                 $post->translated_tldr = $translation?->tldr ?? $post->tldr;
 
                 // Set reading time from translation
@@ -463,7 +464,8 @@ class BlogController
                 }
 
                 // Always set translated properties with fallback to model accessors
-                $seriesPost->translated_slug = $seriesTranslation?->slug ?? $seriesPost->slug;
+                $seriesPost->translated_slug = $seriesTranslation?->slug
+                    ?? $seriesPost->translations->first(fn ($t) => ! empty($t->slug))?->slug;
                 $seriesPost->translated_title = $seriesTranslation?->title ?? $seriesPost->title;
             });
         }
@@ -778,7 +780,8 @@ class BlogController
                 }
 
                 // Set translated properties with fallback to model accessors
-                $post->translated_slug = $translation?->slug ?? $post->slug;
+                $post->translated_slug = $translation?->slug
+                    ?? $post->translations->first(fn ($t) => ! empty($t->slug))?->slug;
                 $post->translated_title = $translation?->title ?? $post->title;
                 $post->translated_tldr = $translation?->tldr ?? $post->tldr;
 

--- a/src/Models/BlogPost.php
+++ b/src/Models/BlogPost.php
@@ -320,7 +320,7 @@ class BlogPost extends Model
     {
         $locale = $this->default_locale ?? config('app.locale', 'en');
 
-        return $this->translate($locale) ?? $this->translations()->first();
+        return $this->translate($locale) ?? $this->translations->first();
     }
 
     /**

--- a/tests/Feature/regression_279_author_page_null_translation_slug.php
+++ b/tests/Feature/regression_279_author_page_null_translation_slug.php
@@ -1,0 +1,67 @@
+<?php
+
+use Happytodev\Blogr\Tests\TestCase;
+
+uses(TestCase::class);
+
+use Happytodev\Blogr\Models\BlogPost;
+use Happytodev\Blogr\Models\Category;
+use Happytodev\Blogr\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+beforeEach(function () {
+    config(['blogr.author_profile.enabled' => true]);
+
+    $this->author = User::create([
+        'name' => 'Test Author',
+        'email' => 'test@example.com',
+        'password' => Hash::make('password123'),
+        'slug' => 'test-author',
+    ]);
+
+    $this->category = Category::create([
+        'name' => 'Tech',
+        'slug' => 'tech',
+    ]);
+});
+
+test('author page renders a post and generates blog.show links without crashing', function () {
+    BlogPost::create([
+        'title' => 'Normal Post',
+        'slug' => 'normal-post',
+        'content' => 'Some content here',
+        'user_id' => $this->author->id,
+        'category_id' => $this->category->id,
+        'is_published' => true,
+        'published_at' => now(),
+    ]);
+
+    $response = $this->get('/blog/author/test-author');
+
+    $response->assertStatus(200);
+    $response->assertSee('Normal Post');
+});
+
+test('author page does not crash when a post has no translations', function () {
+    BlogPost::create([
+        'user_id' => $this->author->id,
+        'category_id' => $this->category->id,
+        'is_published' => true,
+        'published_at' => now(),
+    ]);
+
+    BlogPost::create([
+        'title' => 'Good Post',
+        'slug' => 'good-post',
+        'content' => 'This should work',
+        'user_id' => $this->author->id,
+        'category_id' => $this->category->id,
+        'is_published' => true,
+        'published_at' => now(),
+    ]);
+
+    $response = $this->get('/blog/author/test-author');
+
+    $response->assertStatus(200);
+    $response->assertSee('Good Post');
+});


### PR DESCRIPTION
## Summary

Fix author page crash (`UrlGenerationException: Missing parameter: slug`) when a published post has no translations.

## Changes

- **AuthorController**: Added `->whereHas('translations')` to exclude posts without translations. Changed `translated_slug` fallback to search all eager-loaded translations for a non-null slug.
- **BlogController**: Same slug fallback fix applied to 3 occurrences for consistency.
- **BlogPost**: Fixed N+1 query in `getDefaultTranslation()` by using `$this->translations->first()` (collection) instead of `$this->translations()->first()` (relationship builder).
- **Author view**: Added `?? $post->slug` fallback as defense in depth.

## Test plan

- [x] `vendor/bin/pest --parallel` — 1372 passed (regression test included)
- [x] RED → GREEN → anti-false-positive gate confirmed

## CHANGELOG

- **Author page**: posts without translations no longer cause UrlGenerationException on author profile page (#279)
- **Blog post queries**: fixed N+1 SQL queries in `getDefaultTranslation()` when translations are eager-loaded (#279)