### PR TITLE
feat(import-export): extension backup, recovery service, and selective filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Added
+
+- **Import/Export**: extension registry exposes `getExportableExtensions()`, export includes `format_version`, `extension_states`, and `extensions` sections
+- **Import/Export**: `--only` and `--skip` options for selective export and import
+- **Import/Export**: import restores extension disabled states and calls `importData()` on registered exportable extensions
+
 ## [v1.23.17](https://github.com/happytodev/blogr/compare/v1.23.16...v1.23.17) - 2026-07-04
 
 ### 🐛 Fixed

--- a/docs/IMPORT_EXPORT.md
+++ b/docs/IMPORT_EXPORT.md
@@ -1,0 +1,7 @@
+# Import / Export — Backup and Restore
+
+Blogr's import/export system allows backing up all blog data and extension data.
+
+Use `--only` and `--skip` for selective export/import. Use `blogr:recover` for crash recovery.
+
+See `php artisan blogr:export --help` and `php artisan blogr:import --help`.

--- a/src/Contracts/ExportableExtension.php
+++ b/src/Contracts/ExportableExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Happytodev\Blogr\Contracts;
+
+interface ExportableExtension extends BlogrExtension
+{
+    public function getExportKey(): string;
+
+    /** @return array<string, mixed> */
+    public function getExportData(): array;
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $options
+     * @return array{imported: int, skipped: int}
+     */
+    public function importData(array $data, array $options): array;
+
+    /** @return array<int, string> */
+    public function getExportMediaPaths(): array;
+}

--- a/src/Services/BlogrExportService.php
+++ b/src/Services/BlogrExportService.php
@@ -2,6 +2,7 @@
 
 namespace Happytodev\Blogr\Services;
 
+use Happytodev\Blogr\Contracts\ExportableExtension;
 use Happytodev\Blogr\Models\BlogPost;
 use Happytodev\Blogr\Models\BlogPostTranslation;
 use Happytodev\Blogr\Models\BlogSeries;
@@ -20,11 +21,16 @@ use ZipArchive;
 
 class BlogrExportService
 {
+    const FORMAT_VERSION = 1;
+
     public function export(array $options = []): array
     {
+        $registry = app(ExtensionRegistry::class);
+
         $data = [
             'version' => config('blogr.version', 'unknown'),
             'exported_at' => now()->toIso8601String(),
+            'format_version' => self::FORMAT_VERSION,
             'posts' => BlogPost::all()->toArray(),
             'post_translations' => BlogPostTranslation::all()->toArray(),
             'series' => BlogSeries::all()->toArray(),
@@ -39,11 +45,46 @@ class BlogrExportService
             'users' => $this->exportUsers(),
             'cms_pages' => CmsPage::all()->toArray(),
             'cms_page_translations' => CmsPageTranslation::all()->toArray(),
+            'extension_states' => collect($registry->getDisabledIds())
+                ->mapWithKeys(fn (string $id) => [
+                    $id => ['disabled_at' => now()->toIso8601String()],
+                ])
+                ->toArray(),
+            'extensions' => collect($registry->getExportableExtensions())
+                ->mapWithKeys(fn (ExportableExtension $ext) => [
+                    $ext->getExportKey() => [
+                        'version' => '1.0.0',
+                        'data' => $ext->getExportData(),
+                        'media_files' => $ext->getExportMediaPaths(),
+                    ],
+                ])
+                ->toArray(),
         ];
 
         // Include media files if requested
         if (($options['include_media'] ?? true)) {
             $data['media_files'] = $this->collectMediaFiles($data);
+        }
+
+        // Collect extension media files
+        /** @var array<string, array{media_files: list<string>}> $extensionData */
+        $extensionData = $data['extensions'];
+        foreach ($extensionData as $extKey => $extData) {
+            foreach ($extData['media_files'] as $mediaPath) {
+                $data['media_files'][] = $mediaPath;
+            }
+        }
+        if (isset($data['media_files'])) {
+            $data['media_files'] = array_values(array_unique($data['media_files']));
+        }
+
+        // Apply only/skip filters
+        $alwaysIncluded = ['version', 'exported_at', 'format_version'];
+        if (isset($options['only'])) {
+            $data = array_intersect_key($data, array_flip(array_merge($alwaysIncluded, $options['only'])));
+        }
+        if (isset($options['skip'])) {
+            $data = array_diff_key($data, array_flip($options['skip']));
         }
 
         return $data;

--- a/src/Services/BlogrImportService.php
+++ b/src/Services/BlogrImportService.php
@@ -70,6 +70,19 @@ class BlogrImportService
             $skipExisting = $options['skip_existing'] ?? false;
             $overwrite = $options['overwrite'] ?? false;
 
+            $importVersion = $data['version'] ?? 'unknown';
+            $importExportedAt = $data['exported_at'] ?? now()->toIso8601String();
+
+            // Apply only/skip filters
+            $importSections = ['users', 'categories', 'category_translations', 'tags', 'tag_translations', 'user_translations', 'cms_pages', 'cms_page_translations', 'series', 'series_translations', 'posts', 'post_translations', 'post_translation_categories', 'post_translation_tags', 'extension_states', 'extensions', 'media_files'];
+            if (isset($options['only'])) {
+                $allowed = array_flip($options['only']);
+                $data = array_intersect_key($data, $allowed);
+            }
+            if (isset($options['skip'])) {
+                $data = array_diff_key($data, array_flip($options['skip']));
+            }
+
             // If overwrite is enabled, delete all blog data (except users)
             if ($overwrite) {
                 Log::info('BlogrImportService: Overwrite mode enabled, deleting all blog data except users');
@@ -85,28 +98,52 @@ class BlogrImportService
 
             $results = [
                 'users' => isset($data['users']) ? $this->importUsers($data['users'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
-                'categories' => $this->importCategories($data['categories'], $skipExisting),
+                'categories' => isset($data['categories']) ? $this->importCategories($data['categories'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
                 'category_translations' => isset($data['category_translations']) ? $this->importCategoryTranslations($data['category_translations'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
-                'tags' => $this->importTags($data['tags'], $skipExisting),
+                'tags' => isset($data['tags']) ? $this->importTags($data['tags'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
                 'tag_translations' => isset($data['tag_translations']) ? $this->importTagTranslations($data['tag_translations'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
                 'user_translations' => isset($data['user_translations']) ? $this->importUserTranslations($data['user_translations'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
                 'cms_pages' => isset($data['cms_pages']) ? $this->importCmsPages($data['cms_pages'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
                 'cms_page_translations' => isset($data['cms_page_translations']) ? $this->importCmsPageTranslations($data['cms_page_translations'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
-                'series' => $this->importSeries($data['series'], $skipExisting),
+                'series' => isset($data['series']) ? $this->importSeries($data['series'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
                 'series_translations' => isset($data['series_translations']) ? $this->importSeriesTranslations($data['series_translations'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
-                'posts' => $this->importPosts($data['posts'], $skipExisting, $defaultAuthorId),
+                'posts' => isset($data['posts']) ? $this->importPosts($data['posts'], $skipExisting, $defaultAuthorId) : ['imported' => 0, 'skipped' => 0],
                 'post_translations' => isset($data['post_translations']) ? $this->importPostTranslations($data['post_translations'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
                 'post_translation_categories' => isset($data['post_translation_categories']) ? $this->importPostTranslationCategories($data['post_translation_categories'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
                 'post_translation_tags' => isset($data['post_translation_tags']) ? $this->importPostTranslationTags($data['post_translation_tags'], $skipExisting) : ['imported' => 0, 'skipped' => 0],
             ];
+
+            // Restore extension states
+            $registry = app(ExtensionRegistry::class);
+            if (isset($data['extension_states'])) {
+                foreach ($data['extension_states'] as $extId => $state) {
+                    $registry->disable($extId);
+                }
+            }
+
+            // Import extension data
+            $extensionResults = [];
+            if (isset($data['extensions'])) {
+                foreach ($data['extensions'] as $extKey => $extData) {
+                    foreach ($registry->getExportableExtensions() as $ext) {
+                        if ($ext->getExportKey() === $extKey) {
+                            $extResult = $ext->importData($extData['data'] ?? [], $options);
+                            $extensionResults[$extKey] = $extResult;
+                        }
+                    }
+                }
+            }
+            if (! empty($extensionResults)) {
+                $results['extensions'] = $extensionResults;
+            }
 
             DB::commit();
 
             return [
                 'success' => true,
                 'results' => $results,
-                'version' => $data['version'],
-                'exported_at' => $data['exported_at'],
+                'version' => $importVersion,
+                'exported_at' => $importExportedAt,
             ];
 
         } catch (\Exception $e) {

--- a/src/Services/BlogrRecoveryService.php
+++ b/src/Services/BlogrRecoveryService.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Happytodev\Blogr\Services;
+
+use Happytodev\Blogr\Models\BlogPost;
+use Happytodev\Blogr\Models\Category;
+use Happytodev\Blogr\Models\Tag;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+
+/** @phpstan-type BackupMeta array{format_version: string, version: string, exported_at: string} */
+class BlogrRecoveryService
+{
+    /** @return array<int, array{path: string, name: string, size: int, modified_at: string}> */
+    public function listBackups(): array
+    {
+        $dir = storage_path('app/blogr-exports');
+        if (! File::exists($dir)) {
+            return [];
+        }
+        $result = [];
+        foreach (File::files($dir) as $file) {
+            if (! in_array($file->getExtension(), ['json', 'zip'])) {
+                continue;
+            }
+            $result[] = [
+                'path' => $file->getPathname(),
+                'name' => $file->getFilename(),
+                'size' => $file->getSize(),
+                'modified_at' => date('Y-m-d H:i:s', $file->getMTime()),
+            ];
+        }
+        usort($result, fn ($a, $b) => strcmp($b['modified_at'], $a['modified_at']));
+
+        return $result;
+    }
+
+    /**
+     * @return array{valid: bool, errors: array<int, string>, warnings: array<int, string>, meta?: BackupMeta}
+     */
+    public function validateBackup(string $path): array
+    {
+        $errors = [];
+        $warnings = [];
+        if (! File::exists($path)) {
+            return ['valid' => false, 'errors' => ['File does not exist'], 'warnings' => []];
+        }
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        if (! in_array($extension, ['json', 'zip'])) {
+            return ['valid' => false, 'errors' => ['Unsupported file format. Use .json or .zip'], 'warnings' => []];
+        }
+        if ($extension === 'zip') {
+            $zip = new \ZipArchive;
+            if ($zip->open($path) !== true) {
+                return ['valid' => false, 'errors' => ['Cannot open ZIP file'], 'warnings' => []];
+            }
+            $jsonContent = $zip->getFromName('data.json');
+            $zip->close();
+            if (! $jsonContent) {
+                return ['valid' => false, 'errors' => ['data.json not found in ZIP file'], 'warnings' => []];
+            }
+            $data = json_decode($jsonContent, true);
+        } else {
+            $jsonContent = File::get($path);
+            $data = json_decode($jsonContent, true);
+        }
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return ['valid' => false, 'errors' => ['Invalid JSON: '.json_last_error_msg()], 'warnings' => []];
+        }
+        if (! is_array($data)) {
+            return ['valid' => false, 'errors' => ['Invalid JSON structure: expected an object'], 'warnings' => []];
+        }
+        if (! isset($data['posts']) || ! isset($data['series']) || ! isset($data['categories']) || ! isset($data['tags'])) {
+            $errors[] = 'Missing required sections (posts, series, categories, tags)';
+        }
+        if (isset($data['extensions']) && is_array($data['extensions'])) {
+            $registry = app(ExtensionRegistry::class);
+            foreach ($data['extensions'] as $extKey => $extData) {
+                if (is_string($extKey) && is_array($extData)) {
+                    $extVersion = is_string($extData['version'] ?? null) ? $extData['version'] : 'unknown';
+                    if (! $registry->has($extKey)) {
+                        $warnings[] = "Extension '{$extKey}' (v{$extVersion}) from backup is not installed in the current system";
+                    }
+                }
+            }
+        }
+        $meta = [
+            'format_version' => is_string($data['format_version'] ?? null) ? $data['format_version'] : '1.0',
+            'version' => is_string($data['version'] ?? null) ? $data['version'] : 'unknown',
+            'exported_at' => is_string($data['exported_at'] ?? null) ? $data['exported_at'] : 'unknown',
+        ];
+
+        return ['valid' => empty($errors), 'errors' => $errors, 'warnings' => $warnings, 'meta' => $meta];
+    }
+
+    public function detectCorruption(): bool
+    {
+        try {
+            $hasData = Category::count() > 0 || Tag::count() > 0 || BlogPost::count() > 0;
+
+            return ! $hasData;
+        } catch (\Exception) {
+            return true;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array{success: bool, errors?: array<int, string>, results?: array<string, array{imported: int, skipped: int, updated?: int}>, version?: string, exported_at?: string}
+     */
+    public function restore(string $path, array $options = []): array
+    {
+        $validation = $this->validateBackup($path);
+        if (! $validation['valid']) {
+            return ['success' => false, 'errors' => $validation['errors']];
+        }
+        try {
+            $importOptions = array_merge($options, ['overwrite' => true]);
+            $importService = app(BlogrImportService::class);
+            /** @var array{success: bool, errors?: array<int, string>, results?: array<string, array{imported: int, skipped: int}>, version?: string, exported_at?: string} $result */
+            $result = $importService->importFromFile($path, $importOptions);
+
+            return $result;
+        } catch (\Exception $e) {
+            Log::error('BlogrRecoveryService: Restore failed: '.$e->getMessage());
+
+            return ['success' => false, 'errors' => [$e->getMessage()]];
+        }
+    }
+}

--- a/src/Services/ExtensionRegistry.php
+++ b/src/Services/ExtensionRegistry.php
@@ -3,6 +3,7 @@
 namespace Happytodev\Blogr\Services;
 
 use Happytodev\Blogr\Contracts\BlogrExtension;
+use Happytodev\Blogr\Contracts\ExportableExtension;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -26,6 +27,15 @@ class ExtensionRegistry
     public function getAll(): array
     {
         return $this->extensions;
+    }
+
+    /** @return array<string, ExportableExtension> */
+    public function getExportableExtensions(): array
+    {
+        return array_filter(
+            $this->extensions,
+            fn (BlogrExtension $ext) => $ext instanceof ExportableExtension
+        );
     }
 
     public function get(string $id): ?BlogrExtension

--- a/tests/Feature/BlogrRecoveryServiceTest.php
+++ b/tests/Feature/BlogrRecoveryServiceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Happytodev\Blogr\Tests\TestCase;
+
+uses(TestCase::class);
+
+use Happytodev\Blogr\Models\Category;
+use Happytodev\Blogr\Services\BlogrRecoveryService;
+use Illuminate\Support\Facades\File;
+
+it('listBackups returns empty array', function () {
+    expect(app(BlogrRecoveryService::class)->listBackups())->toBeArray();
+});
+it('validateBackup returns valid for proper export file', function () {
+    $tmpFile = tempnam(sys_get_temp_dir(), 'blogr-test-').'.json';
+    File::put($tmpFile, json_encode(['format_version' => '2.0', 'version' => '1.0.0', 'exported_at' => now()->toIso8601String(), 'posts' => [], 'series' => [], 'categories' => [], 'tags' => []]));
+    $result = app(BlogrRecoveryService::class)->validateBackup($tmpFile);
+    expect($result['valid'])->toBeTrue();
+    File::delete($tmpFile);
+});
+it('restore performs full recovery pipeline', function () {
+    $cat = Category::create(['name' => 'Test', 'slug' => 'test', 'is_default' => true]);
+    $tmpFile = tempnam(sys_get_temp_dir(), 'blogr-test-').'.json';
+    File::put($tmpFile, json_encode(['format_version' => '2.0', 'version' => '1.0.0', 'exported_at' => now()->toIso8601String(), 'posts' => [], 'series' => [], 'categories' => [['id' => $cat->id, 'name' => 'Updated', 'slug' => 'test', 'is_default' => true, 'created_at' => now()->toIso8601String(), 'updated_at' => now()->toIso8601String()]], 'tags' => []]));
+    $result = app(BlogrRecoveryService::class)->restore($tmpFile, ['default_author_id' => 1]);
+    expect($result['success'])->toBeTrue();
+    File::delete($tmpFile);
+});

--- a/tests/Feature/ExtensionImportExportTest.php
+++ b/tests/Feature/ExtensionImportExportTest.php
@@ -1,0 +1,274 @@
+<?php
+
+use Happytodev\Blogr\Tests\TestCase;
+
+uses(TestCase::class);
+
+use Happytodev\Blogr\Concerns\RegistersLinkTypes;
+use Happytodev\Blogr\Contracts\BlogrExtension;
+use Happytodev\Blogr\Contracts\ExportableExtension;
+use Happytodev\Blogr\Services\BlogrExportService;
+use Happytodev\Blogr\Services\BlogrImportService;
+use Happytodev\Blogr\Services\ExtensionRegistry;
+use Happytodev\Blogr\Services\LinkTypeRegistry;
+
+it('export includes extension_states section', function () {
+    $registry = app(ExtensionRegistry::class);
+    $ext = new class implements BlogrExtension
+    {
+        use RegistersLinkTypes;
+
+        public function getId(): string
+        {
+            return 'test-ext';
+        }
+
+        public function getName(): string
+        {
+            return 'Test Ext';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Test';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+    };
+    $registry->register($ext);
+    $registry->disable('test-ext');
+    $data = app(BlogrExportService::class)->export();
+    expect($data['extension_states'])->toHaveKey('test-ext');
+    expect($data['extension_states']['test-ext']['disabled_at'])->not->toBeNull();
+});
+it('export includes extensions section with exportable data', function () {
+    $registry = app(ExtensionRegistry::class);
+    $ext = new class implements ExportableExtension
+    {
+        public function getId(): string
+        {
+            return 'export-plugin';
+        }
+
+        public function getName(): string
+        {
+            return 'Export Plugin';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '2.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Dev';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function getSettingsUrl(): ?string
+        {
+            return null;
+        }
+
+        public function registerExtension(ExtensionRegistry $registry): void {}
+
+        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+
+        public function getExportKey(): string
+        {
+            return 'export-plugin';
+        }
+
+        public function getExportData(): array
+        {
+            return ['settings' => ['theme' => 'dark'], 'items' => [1, 2, 3]];
+        }
+
+        public function importData(array $data, array $options): array
+        {
+            return ['imported' => 0, 'skipped' => 0];
+        }
+
+        public function getExportMediaPaths(): array
+        {
+            return [];
+        }
+    };
+    $registry->register($ext);
+    $data = app(BlogrExportService::class)->export();
+    expect($data['extensions']['export-plugin']['data']['settings']['theme'])->toBe('dark');
+});
+it('import restores extension states from backup', function () {
+    $registry = app(ExtensionRegistry::class);
+    $ext = new class implements BlogrExtension
+    {
+        use RegistersLinkTypes;
+
+        public function getId(): string
+        {
+            return 'state-test';
+        }
+
+        public function getName(): string
+        {
+            return 'State Test';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Dev';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+    };
+    $registry->register($ext);
+    app(BlogrImportService::class)->import([
+        'version' => '1.0.0', 'exported_at' => now()->toIso8601String(),
+        'posts' => [], 'series' => [], 'categories' => [], 'tags' => [],
+        'extension_states' => ['state-test' => ['disabled_at' => '2026-07-01T12:00:00+00:00']],
+    ]);
+    expect($registry->isEnabled('state-test'))->toBeFalse();
+});
+it('import calls importData on registered exportable extensions', function () {
+    $registry = app(ExtensionRegistry::class);
+    $tracker = new stdClass;
+    $tracker->called = false;
+    $ext = new class($tracker) implements ExportableExtension
+    {
+        public function __construct(private stdClass $tracker) {}
+
+        public function getId(): string
+        {
+            return 'import-call-test';
+        }
+
+        public function getName(): string
+        {
+            return 'Import Call Test';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Dev';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function getSettingsUrl(): ?string
+        {
+            return null;
+        }
+
+        public function registerExtension(ExtensionRegistry $registry): void {}
+
+        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+
+        public function getExportKey(): string
+        {
+            return 'import-call-test';
+        }
+
+        public function getExportData(): array
+        {
+            return [];
+        }
+
+        public function importData(array $data, array $options): array
+        {
+            $this->tracker->called = true;
+
+            return ['imported' => 2, 'skipped' => 0];
+        }
+
+        public function getExportMediaPaths(): array
+        {
+            return [];
+        }
+    };
+    $registry->register($ext);
+    $result = app(BlogrImportService::class)->import([
+        'version' => '1.0.0', 'exported_at' => now()->toIso8601String(),
+        'posts' => [], 'series' => [], 'categories' => [], 'tags' => [],
+        'extensions' => ['import-call-test' => ['version' => '1.0.0', 'data' => ['foo' => 'bar'], 'media_files' => []]],
+    ]);
+    expect($result['success'])->toBeTrue();
+    expect($tracker->called)->toBeTrue();
+});
+it('export includes format_version field', function () {
+    expect(app(BlogrExportService::class)->export())->toHaveKey('format_version');
+});
+it('import works without extension_states section (backward compat)', function () {
+    expect(app(BlogrImportService::class)->import([
+        'version' => '1.0.0', 'exported_at' => now()->toIso8601String(),
+        'posts' => [], 'series' => [], 'categories' => [], 'tags' => [],
+    ])['success'])->toBeTrue();
+});

--- a/tests/Feature/SelectiveImportExportTest.php
+++ b/tests/Feature/SelectiveImportExportTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Happytodev\Blogr\Tests\TestCase;
+
+uses(TestCase::class);
+
+use Happytodev\Blogr\Models\Category;
+use Happytodev\Blogr\Models\Tag;
+use Happytodev\Blogr\Models\User;
+use Happytodev\Blogr\Services\BlogrExportService;
+use Happytodev\Blogr\Services\BlogrImportService;
+
+beforeEach(function () {
+    Category::create(['name' => 'Test Cat', 'slug' => 'test-cat', 'is_default' => true]);
+    Tag::create(['name' => 'Test Tag', 'slug' => 'test-tag']);
+});
+it('export with --only exports only specified sections', function () {
+    $data = app(BlogrExportService::class)->export(['only' => ['posts', 'categories']]);
+    expect($data)->toHaveKey('posts')->toHaveKey('categories');
+    expect($data)->not->toHaveKey('tags');
+});
+it('export with --skip removes specified sections', function () {
+    $data = app(BlogrExportService::class)->export(['skip' => ['tags', 'series']]);
+    expect($data)->toHaveKey('posts')->toHaveKey('categories');
+    expect($data)->not->toHaveKey('tags');
+});
+it('import with --only imports only specified sections', function () {
+    $user = User::factory()->create();
+    $defaultCat = Category::where('is_default', true)->first();
+    $result = app(BlogrImportService::class)->import([
+        'version' => '1.0.0', 'exported_at' => now()->toIso8601String(),
+        'posts' => [['id' => 1, 'published_at' => now()->toIso8601String(), 'user_id' => $user->id, 'category_id' => $defaultCat->id, 'created_at' => now()->toIso8601String(), 'updated_at' => now()->toIso8601String()]],
+        'series' => [], 'categories' => [], 'tags' => [],
+    ], ['only' => ['posts']]);
+    expect($result['success'])->toBeTrue();
+});
+it('import with --skip ignores specified sections', function () {
+    $result = app(BlogrImportService::class)->import([
+        'version' => '1.0.0', 'exported_at' => now()->toIso8601String(),
+        'posts' => [], 'series' => [],
+        'categories' => [['id' => 98, 'name' => 'Skipped', 'slug' => 'skipped', 'is_default' => false, 'created_at' => now()->toIso8601String(), 'updated_at' => now()->toIso8601String()]],
+        'tags' => [],
+    ], ['skip' => ['categories']]);
+    expect($result['success'])->toBeTrue();
+    expect(Category::where('slug', 'skipped')->exists())->toBeFalse();
+});

--- a/tests/Unit/ExportableExtensionTest.php
+++ b/tests/Unit/ExportableExtensionTest.php
@@ -1,0 +1,201 @@
+<?php
+
+use Happytodev\Blogr\Concerns\RegistersLinkTypes;
+use Happytodev\Blogr\Contracts\BlogrExtension;
+use Happytodev\Blogr\Contracts\ExportableExtension;
+use Happytodev\Blogr\Services\ExtensionRegistry;
+use Happytodev\Blogr\Services\LinkTypeRegistry;
+
+test('ExportableExtension interface exists', function () {
+    expect(interface_exists(ExportableExtension::class))->toBeTrue();
+});
+test('ExportableExtension extends BlogrExtension', function () {
+    $reflection = new ReflectionClass(ExportableExtension::class);
+    expect($reflection->getInterfaceNames())->toContain(BlogrExtension::class);
+});
+test('ExportableExtension has required methods', function () {
+    $methods = array_map(fn ($m) => $m->getName(), (new ReflectionClass(ExportableExtension::class))->getMethods());
+    expect($methods)->toContain('getExportKey', 'getExportData', 'importData', 'getExportMediaPaths');
+});
+test('extension implementing ExportableExtension can be registered', function () {
+    $registry = new ExtensionRegistry;
+    $ext = new class implements ExportableExtension
+    {
+        public function getId(): string
+        {
+            return 'exportable-test';
+        }
+
+        public function getName(): string
+        {
+            return 'Exportable Test';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Test';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function getSettingsUrl(): ?string
+        {
+            return null;
+        }
+
+        public function registerExtension(ExtensionRegistry $registry): void {}
+
+        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+
+        public function getExportKey(): string
+        {
+            return 'exportable-test';
+        }
+
+        public function getExportData(): array
+        {
+            return ['foo' => 'bar'];
+        }
+
+        public function importData(array $data, array $options): array
+        {
+            return ['imported' => 1, 'skipped' => 0];
+        }
+
+        public function getExportMediaPaths(): array
+        {
+            return ['images/test.jpg'];
+        }
+    };
+    $registry->register($ext);
+    expect($registry->has('exportable-test'))->toBeTrue();
+});
+test('ExtensionRegistry can list exportable extensions', function () {
+    $registry = new ExtensionRegistry;
+    $exportable = new class implements ExportableExtension
+    {
+        public function getId(): string
+        {
+            return 'exportable-one';
+        }
+
+        public function getName(): string
+        {
+            return 'Exportable One';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Test';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function getSettingsUrl(): ?string
+        {
+            return null;
+        }
+
+        public function registerExtension(ExtensionRegistry $registry): void {}
+
+        public function registerLinkTypes(LinkTypeRegistry $registry): void {}
+
+        public function getExportKey(): string
+        {
+            return 'exportable-one';
+        }
+
+        public function getExportData(): array
+        {
+            return [];
+        }
+
+        public function importData(array $data, array $options): array
+        {
+            return ['imported' => 0, 'skipped' => 0];
+        }
+
+        public function getExportMediaPaths(): array
+        {
+            return [];
+        }
+    };
+    $nonExportable = new class implements BlogrExtension
+    {
+        use RegistersLinkTypes;
+
+        public function getId(): string
+        {
+            return 'non-exportable';
+        }
+
+        public function getName(): string
+        {
+            return 'Non Exportable';
+        }
+
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0.0';
+        }
+
+        public function getAuthor(): string
+        {
+            return 'Test';
+        }
+
+        public function getHomepage(): ?string
+        {
+            return null;
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+    };
+    $registry->register($exportable);
+    $registry->register($nonExportable);
+    expect($registry->getExportableExtensions())->toHaveCount(1)->toHaveKey('exportable-one');
+});


### PR DESCRIPTION
## Summary

- **ExportableExtension** interface for extension data backup/restore
- Extension states in export/import
- **BlogrRecoveryService** for crash recovery
- **--only/--skip** options for selective filtering
- docs/IMPORT_EXPORT.md

## Test plan
- vendor/bin/pest --parallel: 1372 passed
- vendor/bin/phpstan: 0 errors