### PR TITLE
feat: WCAG accessibility sprint 1 and 2 (A + AA quick wins)

### DIFF
--- a/docs/WCAG.md
+++ b/docs/WCAG.md
@@ -1,0 +1,94 @@
+# WCAG Accessibility Implementation
+
+**Target level:** WCAG 2.2 Level AA (Level A achieved — partial)
+
+## Conformance status
+
+| Level | Status | Details |
+|-------|--------|---------|
+| A | ✅ Partial (5/10 criteria) | Critical barriers resolved |
+| AA | 🔄 In progress | 6 criteria remaining |
+| AAA | ❌ Not targeted | Not required by regulations |
+
+## Implemented (Sprint 0 — completed)
+
+| WCAG SC | Description | Component | Issue |
+|---------|-------------|-----------|-------|
+| 2.4.1 (A) | Skip-to-content link — bypass navigation blocks | `layouts/blog.blade.php` | #285 |
+| 3.3.2 (A) | Form label on newsletter email input | `newsletter.blade.php` | #285 |
+| 2.1.1 + 4.1.2 (A) | Keyboard-accessible gallery images (`tabindex`, `role`, keydown) | `gallery.blade.php` | #285 |
+| 2.1.1 + 2.2.2 (A) | Keyboard-navigable carousel with focus-based autoplay pause | `carousel.blade.php` | #285 |
+
+## In progress (Sprints 1–5)
+
+### Sprint 1 — Quick wins
+
+| # | WCAG SC | Description | Component |
+|---|---------|-------------|-----------|
+| 291 | 2.4.4 (A) | `aria-label` on "Read More" links | `blog-post-card.blade.php` |
+| 295 | 4.1.2 (A) | `aria-pressed` on theme switcher buttons | `navigation.blade.php` |
+| 287 | 1.3.5 (AA) | `autocomplete` attributes on forms | `contact_form.blade.php`, `newsletter.blade.php` |
+
+### Sprint 2 — Keyboard navigation (A)
+
+| # | WCAG SC | Description | Component |
+|---|---------|-------------|-----------|
+| 294 | 2.1.1 (A) | Escape key + focus management on language switcher | `language-switcher.blade.php` |
+| 292 | 2.1.1 (A) | Full keyboard support + ARIA on mega menu | `navigation.blade.php` |
+
+### Sprint 3 — Dynamic content (AA)
+
+| # | WCAG SC | Description | Component |
+|---|---------|-------------|-----------|
+| 290 | 4.1.3 (AA) | `role="status"` / `aria-live` on dynamic messages | `contact_form.blade.php`, `newsletter.blade.php`, code copy script |
+| 293 | 2.2.2 (A) | Pause/Play button + `prefers-reduced-motion` on carousel | `carousel.blade.php` |
+
+### Sprint 4 — Visual / design (AA)
+
+| # | WCAG SC | Description | Component |
+|---|---------|-------------|-----------|
+| 288 | 2.4.11 (AA) | `scroll-margin-top` to prevent sticky nav obscuring focus | `layouts/blog.blade.php` |
+| 289 | 2.5.8 (AA) | Touch targets ≥ 24×24px for icons and tags | `social-links.blade.php` |
+
+### Sprint 5 — Color system (AA)
+
+| # | WCAG SC | Description | Component |
+|---|---------|-------------|-----------|
+| 286 | 1.4.3 (AA) | Contrast ratio validation (4.5:1) for user-configurable colors | `ConfigHelper`, `BlogrSettings` |
+
+## Architecture notes
+
+### Skip link
+- First focusable element after `<body>`
+- Visually hidden via `sr-only`, appears on `:focus` via `focus:not-sr-only`
+- Targets `<main id="main-content">`
+
+### Gallery keyboard access
+- All 5 layout modes (grid, horizontal, filtered, masonry, bento) have clickable `<div>` elements with `tabindex="0"`, `role="button"`, `@keydown.enter`, `@keydown.space.prevent`
+- Lightbox has Escape, arrow keys, and aria-labels on prev/next/close buttons
+
+### Carousel
+- Arrow keys (`@keydown.arrow-right/.arrow-left`) navigate slides
+- Focus-based autoplay pause/resume (`@focusin`/`@focusout`)
+- All navigation buttons have `aria-label`
+- Dot indicators have `aria-label="Go to slide N"`
+
+### Newsletter form
+- Email input has `<label for="newsletter-email" class="sr-only">`
+- Input has `id="newsletter-email"` matching the `for` attribute
+
+## Testing
+
+Accessibility tests live in `tests/Feature/Accessibility/`:
+
+```bash
+vendor/bin/pest --filter "feature_skip_to_content_link|feature_newsletter_form|feature_gallery.*keyboard|feature_carousel"
+```
+
+Each fix follows TDD: RED (test fails before fix) → GREEN (test passes after) → anti-false-positive gate (test fails when implementation is removed).
+
+## References
+
+- [WCAG 2.2 Specification](https://www.w3.org/TR/WCAG22/)
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
+- GitHub issues: [#285](https://github.com/happytodev/blogr/issues/285) (critical A fixes), [#286–#295](https://github.com/happytodev/blogr/issues?q=is%3Aissue+is%3Aopen+label%3Aaccessibility) (remaining)

--- a/resources/views/components/blocks/contact_form.blade.php
+++ b/resources/views/components/blocks/contact_form.blade.php
@@ -150,6 +150,7 @@
                             id="{{ $uniqueId }}-name"
                             type="text"
                             x-model="name"
+                            autocomplete="name"
                             required
                             class="w-full px-4 py-3 rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
                             placeholder="{{ __('John Doe') }}"
@@ -163,6 +164,7 @@
                             id="{{ $uniqueId }}-email"
                             type="email"
                             x-model="email"
+                            autocomplete="email"
                             required
                             class="w-full px-4 py-3 rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
                             placeholder="{{ __('john@example.com') }}"
@@ -178,6 +180,7 @@
                         id="{{ $uniqueId }}-subject"
                         type="text"
                         x-model="subject"
+                        autocomplete="subject"
                         required
                         class="w-full px-4 py-3 rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
                         placeholder="{{ __('How can we help you?') }}"

--- a/resources/views/components/blocks/newsletter.blade.php
+++ b/resources/views/components/blocks/newsletter.blade.php
@@ -51,6 +51,7 @@
                     name="email"
                     id="newsletter-email"
                     x-model="email"
+                    autocomplete="email"
                     placeholder="{{ $placeholder }}"
                     required
                     class="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-600 focus:border-transparent"

--- a/resources/views/components/blog-post-card.blade.php
+++ b/resources/views/components/blog-post-card.blade.php
@@ -134,6 +134,7 @@
 
                 <!-- Read More Button -->
                 <a href="{{ config('blogr.locales.enabled') ? route('blog.show', ['locale' => $currentLocale, 'slug' => $postSlug]) : route('blog.show', ['slug' => $postSlug]) }}"
+                    aria-label="Read more about {{ $postTitle }}"
                     class="inline-flex items-center text-[var(--color-primary)] dark:text-[var(--color-primary-dark)] hover:text-[var(--color-primary-hover)] dark:hover:text-[var(--color-primary-hover-dark)] font-semibold text-sm group/link ml-auto">
                     {{ __('blogr::blogr.ui.read_more') }}
                     <svg class="w-4 h-4 ml-1 group-hover/link:translate-x-1 transition-transform"

--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -190,8 +190,13 @@
                         <div class="relative" 
                              x-data="{ open: false }"
                              @mouseenter="open = true" 
-                             @mouseleave="open = false">
-                            <button class="flex items-center space-x-1 px-4 py-2 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+                             @mouseleave="open = false"
+                             @focusin="open = true"
+                             @focusout="open = false"
+                             @keydown.escape.prevent="open = false">
+                            <button class="flex items-center space-x-1 px-4 py-2 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                                    aria-haspopup="true"
+                                    :aria-expanded="open">
                                 <span>{{ $label }}</span>
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
@@ -267,7 +272,8 @@
                 <!-- Language Switcher -->
                 @if(config('blogr.ui.navigation.show_language_switcher', true) && config('blogr.locales.enabled', false) && count($availableLocales) > 1)
                 <div class="relative" x-data="{ open: false }">
-                    <button @click="open = !open" @click.away="open = false" 
+                    <button @click="open = !open" @click.away="open = false" @keydown.escape.prevent="open = false"
+                            :aria-expanded="open"
                             class="flex items-center space-x-1 px-3 py-2 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"></path>
@@ -293,8 +299,9 @@
                         <div class="py-1" role="menu">
                             @foreach($availableLocales as $locale)
                             @php
-                                $currentRouteName = request()->route()->getName();
-                                $currentParams = request()->route()->parameters();
+                                $currentRoute = request()->route();
+                                $currentRouteName = $currentRoute ? $currentRoute->getName() : 'blog.index';
+                                $currentParams = $currentRoute ? $currentRoute->parameters() : [];
                                 
                                 // For CMS pages, get the translated slug if it exists
                                 if ($currentRouteName === 'cms.page.show' && $cmsPageId) {
@@ -346,6 +353,7 @@
                 <div x-data="themeSwitch()" class="flex items-center space-x-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
                     <button @click="setTheme('light')" 
                             :class="{ 'bg-white dark:bg-gray-700 shadow': theme === 'light' }"
+                            :aria-pressed="theme === 'light'"
                             class="p-2 rounded-md transition-all duration-200"
                             title="Light mode">
                         <svg class="w-5 h-5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
@@ -354,6 +362,7 @@
                     </button>
                     <button @click="setTheme('auto')" 
                             :class="{ 'bg-white dark:bg-gray-700 shadow': theme === 'auto' }"
+                            :aria-pressed="theme === 'auto'"
                             class="p-2 rounded-md transition-all duration-200"
                             title="Auto mode">
                         <svg class="w-5 h-5 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 20 20">
@@ -362,6 +371,7 @@
                     </button>
                     <button @click="setTheme('dark')" 
                             :class="{ 'bg-white dark:bg-gray-700 shadow': theme === 'dark' }"
+                            :aria-pressed="theme === 'dark'"
                             class="p-2 rounded-md transition-all duration-200"
                             title="Dark mode">
                         <svg class="w-5 h-5 text-indigo-600 dark:text-indigo-400" fill="currentColor" viewBox="0 0 20 20">

--- a/tests/Feature/Accessibility/FormAutocompleteTest.php
+++ b/tests/Feature/Accessibility/FormAutocompleteTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Happytodev\Blogr\Tests\TestCase;
+use Illuminate\Support\Facades\View;
+
+uses(TestCase::class);
+
+test('feature_contact_form_name_has_autocomplete', function () {
+    $data = [
+        'heading' => 'Contact Us',
+        'to_email' => 'test@example.com',
+    ];
+
+    $html = View::make('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    expect($html)
+        ->toContain('autocomplete="name"');
+});
+
+test('feature_contact_form_email_has_autocomplete', function () {
+    $data = [
+        'heading' => 'Contact Us',
+        'to_email' => 'test@example.com',
+    ];
+
+    $html = View::make('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    expect($html)
+        ->toContain('autocomplete="email"');
+});
+
+test('feature_contact_form_subject_has_autocomplete', function () {
+    $data = [
+        'heading' => 'Contact Us',
+        'to_email' => 'test@example.com',
+    ];
+
+    $html = View::make('blogr::components.blocks.contact_form', ['data' => $data])->render();
+
+    expect($html)
+        ->toContain('autocomplete="subject"');
+});

--- a/tests/Feature/Accessibility/LanguageSwitcherKeyboardTest.php
+++ b/tests/Feature/Accessibility/LanguageSwitcherKeyboardTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Happytodev\Blogr\Tests\TestCase;
+use Illuminate\Support\Facades\View;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    config(['blogr.ui.navigation.enabled' => true]);
+    config(['blogr.ui.navigation.show_theme_switcher' => false]);
+    config(['blogr.ui.navigation.menu_items' => []]);
+    config(['blogr.rss.show_in_header' => false]);
+    config(['blogr.ui.navigation.show_language_switcher' => true]);
+    config(['blogr.locales.enabled' => true]);
+    config(['blogr.locales.default' => 'en']);
+    config(['blogr.locales.available' => ['en', 'fr']]);
+
+    view()->share('seoData', [
+        'title' => 'Blog',
+        'description' => 'Test',
+    ]);
+    view()->share('currentLocale', 'en');
+});
+
+test('feature_language_switcher_handles_escape_key', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en', 'fr'],
+    ])->render();
+
+    expect($html)
+        ->toContain('@keydown.escape');
+});
+
+test('feature_language_switcher_trigger_has_aria_expanded', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en', 'fr'],
+    ])->render();
+
+    expect($html)
+        ->toContain('aria-expanded');
+});
+
+test('feature_language_switcher_items_have_role_menuitem', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en', 'fr'],
+    ])->render();
+
+    expect($html)
+        ->toContain('role="menuitem"');
+});

--- a/tests/Feature/Accessibility/MegaMenuKeyboardTest.php
+++ b/tests/Feature/Accessibility/MegaMenuKeyboardTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Happytodev\Blogr\Tests\TestCase;
+use Illuminate\Support\Facades\View;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    config(['blogr.ui.navigation.enabled' => true]);
+    config(['blogr.ui.navigation.show_theme_switcher' => false]);
+    config(['blogr.rss.show_in_header' => false]);
+    config(['blogr.locales.enabled' => false]);
+    config(['blogr.ui.navigation.menu_items' => [
+        [
+            'labels' => [['locale' => 'en', 'label' => 'Services']],
+            'type' => 'megamenu',
+            'children' => [
+                ['labels' => [['locale' => 'en', 'label' => 'Web Design']], 'type' => 'external', 'url' => '#'],
+                ['labels' => [['locale' => 'en', 'label' => 'SEO']], 'type' => 'external', 'url' => '#'],
+            ],
+        ],
+    ]]);
+});
+
+test('feature_mega_menu_trigger_has_aria_expanded', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en'],
+    ])->render();
+
+    expect($html)
+        ->toContain('aria-expanded');
+});
+
+test('feature_mega_menu_trigger_has_aria_haspopup', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en'],
+    ])->render();
+
+    expect($html)
+        ->toContain('aria-haspopup="true"');
+});
+
+test('feature_mega_menu_opens_on_focus', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en'],
+    ])->render();
+
+    // Should have @focus handling in addition to @mouseenter
+    expect($html)
+        ->toContain('@mouseenter')
+        ->toContain('@focus');
+});

--- a/tests/Feature/Accessibility/ReadMoreLinkAriaLabelTest.php
+++ b/tests/Feature/Accessibility/ReadMoreLinkAriaLabelTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Happytodev\Blogr\Models\BlogPost;
+use Happytodev\Blogr\Models\Category;
+use Happytodev\Blogr\Models\User;
+use Happytodev\Blogr\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\View;
+
+uses(TestCase::class);
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['blogr.route.frontend.enabled' => true]);
+    config(['blogr.ui.dates.show_publication_date' => false]);
+    config(['blogr.display.show_author_pseudo' => false]);
+    config(['blogr.display.show_author_avatar' => false]);
+    config(['blogr.reading_time.enabled' => false]);
+});
+
+test('feature_read_more_link_has_aria_label', function () {
+    $category = Category::factory()->create();
+    $user = User::factory()->create();
+    $post = BlogPost::factory()->create([
+        'user_id' => $user->id,
+        'category_id' => $category->id,
+    ]);
+
+    $postTranslation = $post->translations()->first();
+    $postTranslation->update(['title' => 'Test Post Title']);
+
+    $html = View::make('blogr::components.blog-post-card', [
+        'post' => $post,
+        'currentLocale' => 'en',
+    ])->render();
+
+    expect($html)
+        ->toContain('aria-label')
+        ->toContain('Read more about');
+});

--- a/tests/Feature/Accessibility/ThemeSwitcherAriaPressedTest.php
+++ b/tests/Feature/Accessibility/ThemeSwitcherAriaPressedTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Happytodev\Blogr\Tests\TestCase;
+use Illuminate\Support\Facades\View;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    config(['blogr.ui.navigation.enabled' => true]);
+    config(['blogr.ui.navigation.show_theme_switcher' => true]);
+    config(['blogr.ui.navigation.menu_items' => []]);
+    config(['blogr.locales.enabled' => false]);
+    config(['blogr.rss.show_in_header' => false]);
+});
+
+test('feature_theme_switcher_buttons_have_aria_pressed', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en'],
+    ])->render();
+
+    expect($html)
+        ->toContain('aria-pressed');
+});
+
+test('feature_theme_switcher_light_button_has_aria_pressed', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en'],
+    ])->render();
+
+    expect($html)
+        ->toMatch('/aria-pressed=".*light.*"/');
+});
+
+test('feature_theme_switcher_auto_button_has_aria_pressed', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en'],
+    ])->render();
+
+    expect($html)
+        ->toMatch('/aria-pressed=".*auto.*"/');
+});
+
+test('feature_theme_switcher_dark_button_has_aria_pressed', function () {
+    $html = View::make('blogr::components.navigation', [
+        'currentLocale' => 'en',
+        'availableLocales' => ['en'],
+    ])->render();
+
+    expect($html)
+        ->toMatch('/aria-pressed=".*dark.*"/');
+});


### PR DESCRIPTION
## Summary

Sprint 1 and 2 of the WCAG accessibility roadmap: 5 issues resolved with 14 new regression tests.

### Sprint 1 — Quick wins

| # | Issue | Fix |
|---|-------|-----|
| #291 | Read More links | Add `aria-label="Read more about {title}"` on blog post cards |
| #295 | Theme switcher | Add `:aria-pressed" to light/auto/dark buttons |
| #287 | Form autocomplete | Add `autocomplete="name/email/subject"` to contact and newsletter forms |

### Sprint 2 — Keyboard navigation (A)

| # | Issue | Fix |
|---|-------|-----|
| #294 | Language switcher | Add `@keydown.escape`, `:aria-expanded`, null-safe route access |
| #292 | Mega menu | Add `aria-haspopup`, `:aria-expanded`, `@focusin/out`, Escape key |

### Also included
- PHPStan fixes for pre-existing errors in `BlogrSettings.php` and `ShikiCodeBlockRenderer.php`
- `docs/WCAG.md` — full accessibility conformance documentation

## Test plan

- [x] `vendor/bin/pest --parallel` — 1,363 passed, 0 failures
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] `vendor/bin/pint` — passed
- [x] 14 new regression tests