### PR TITLE
feat: callout editor buttons, improved icons, WCAG toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **callouts**: Icons now always render (with or without title) — better visual identification at a glance
+- **callouts**: Improved icon hierarchy — `caution` uses warning triangle, `danger` uses prohibitive x-circle
+- **callouts**: Icons upgraded to Heroicons v2 outline at 32px with `stroke-width="1.5"` for crisper details
+- **callouts**: Title font-size increased to 1.125rem, content font-size set to 0.75rem
+- **callouts**: CSS styling included in PDF exports — callouts render with colors and borders in generated PDFs
+- **editor**: New `CalloutMarkdownEditor` field extending `MarkdownEditor` — adds 4 dedicated toolbar buttons (Tip, Info, Caution, Danger) that insert callout templates at cursor position
+- **editor**: `CalloutMarkdownEditor` replaces `MarkdownEditor` in all blog post, docs, CMS, profile and author bio forms
+
+### 🐛 Fixed
+
+- **callouts**: `CalloutStartParser` now returns `->at($cursor)` — correct cursor advancement after parsing
+
+### 🧪 Tests
+
+- `CalloutMarkdownEditorTest` — class extension, view path, button structure and accessibility attributes
+- `AuthorBioFieldEnhancementsTest` — updated assertions for `CalloutMarkdownEditor`
+- `DocSettingsTest` — PDF template includes callout CSS styling
+
 ## [v1.27.0](https://github.com/happytodev/blogr/compare/v1.26.0...v1.27.0) - 2026-07-05
 
 ### ✨ Features

--- a/resources/views/components/callout-markdown-editor.blade.php
+++ b/resources/views/components/callout-markdown-editor.blade.php
@@ -1,0 +1,131 @@
+@php
+    $id = $getId();
+    $fieldWrapperView = $getFieldWrapperView();
+    $extraAttributeBag = $getExtraAttributeBag();
+    $key = $getKey();
+    $label = $getLabel();
+    $statePath = $getStatePath();
+    $fileAttachmentsMaxSize = $getFileAttachmentsMaxSize();
+    $fileAttachmentsAcceptedFileTypes = $getFileAttachmentsAcceptedFileTypes();
+@endphp
+
+<x-dynamic-component :component="$fieldWrapperView" :field="$field">
+    @if ($isDisabled())
+        <div id="{{ $id }}" class="fi-fo-markdown-editor fi-disabled fi-prose">
+            {!! str($getState())->markdown($getCommonMarkOptions(), $getCommonMarkExtensions())->sanitizeHtml() !!}
+        </div>
+    @else
+        <x-filament::input.wrapper
+            :valid="! $errors->has($statePath)"
+            :attributes="
+                \Filament\Support\prepare_inherited_attributes($extraAttributeBag)
+                    ->class(['fi-fo-markdown-editor'])
+            "
+        >
+            <div
+                aria-labelledby="{{ $id }}-label"
+                id="{{ $id }}"
+                role="group"
+                x-load
+                x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('markdown-editor', 'filament/forms') }}"
+                x-data="markdownEditorFormComponent({
+                            canAttachFiles: @js($hasFileAttachments()),
+                            isLiveDebounced: @js($isLiveDebounced()),
+                            isLiveOnBlur: @js($isLiveOnBlur()),
+                            label: @js($label),
+                            liveDebounce: @js($getNormalizedLiveDebounce()),
+                            maxHeight: @js($getMaxHeight()),
+                            minHeight: @js($getMinHeight()),
+                            placeholder: @js($getPlaceholder()),
+                            state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')", isOptimisticallyLive: false) }},
+                            toolbarButtons: @js($getToolbarButtons()),
+                            translations: @js(__('filament-forms::components.markdown_editor')),
+                            uploadFileAttachmentUsing: async (file, onSuccess, onError) => {
+                                const acceptedTypes = @js($fileAttachmentsAcceptedFileTypes)
+
+                                if (acceptedTypes && ! acceptedTypes.includes(file.type)) {
+                                    return onError(@js($fileAttachmentsAcceptedFileTypes ? __('filament-forms::components.markdown_editor.file_attachments_accepted_file_types_message', ['values' => implode(', ', $fileAttachmentsAcceptedFileTypes)]) : null))
+                                }
+
+                                const maxSize = @js($fileAttachmentsMaxSize)
+
+                                if (maxSize && file.size > +maxSize * 1024) {
+                                    return onError(@js($fileAttachmentsMaxSize ? trans_choice('filament-forms::components.markdown_editor.file_attachments_max_size_message', $fileAttachmentsMaxSize, ['max' => $fileAttachmentsMaxSize]) : null))
+                                }
+
+                                $wire.upload(`componentFileAttachments.{{ $statePath }}`, file, () => {
+                                    $wire
+                                        .callSchemaComponentMethod(
+                                            '{{ $key }}',
+                                            'saveUploadedFileAttachmentAndGetUrl',
+                                        )
+                                        .then((url) => {
+                                            if (! url) {
+                                                return onError()
+                                            }
+
+                                            onSuccess(url)
+                                        })
+                                })
+                            },
+                        })"
+                wire:ignore
+                {{ $getExtraAlpineAttributeBag() }}
+            >
+                <textarea x-ref="editor" x-cloak></textarea>
+            </div>
+        </x-filament::input.wrapper>
+        @once
+            <style>
+                .editor-toolbar .callout-btn::before,
+                .editor-toolbar .callout-btn::after {
+                    content: none !important;
+                    display: none !important;
+                }
+                .editor-toolbar .callout-btn svg {
+                    display: block;
+                    pointer-events: none;
+                }
+                .editor-toolbar .callout-btn {
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                }
+            </style>
+        @endonce
+        @php
+            $calloutId = $id;
+        @endphp
+        <script>
+            (function() {
+                var check = setInterval(function() {
+                    var el = document.getElementById('{{ $calloutId }}');
+                    if (!el || !el._editor) return;
+                    clearInterval(check);
+                    var editor = el._editor;
+                    var tb = editor.gui.toolbar;
+                    var sep = document.createElement('div');
+                    sep.className = 'separator';
+                    tb.appendChild(sep);
+                    var callouts = [
+                        {label:'Tip', cls:'callout-btn', icon:'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>', tpl:':::tip[Lorem]\nIpsum sit amet *em dolorem*.\n:::'},
+                        {label:'Info', cls:'callout-btn', icon:'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>', tpl:':::info[Lorem]\nIpsum sit amet.\n:::'},
+                        {label:'Caution', cls:'callout-btn', icon:'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>', tpl:':::caution[Lorem]\nIpsum sit amet.\n:::'},
+                        {label:'Danger', cls:'callout-btn', icon:'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 9l6 6m0-6l-6 6M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>', tpl:':::danger[Lorem]\nIpsum sit amet.\n:::'},
+                    ];
+                    callouts.forEach(function(c) {
+                        var btn = document.createElement('button');
+                        btn.className = c.cls;
+                        btn.innerHTML = c.icon;
+                        btn.setAttribute('aria-label', 'Insert ' + c.label.toLowerCase() + ' callout');
+                        btn.setAttribute('title', c.label);
+                        btn.addEventListener('click', function() {
+                            editor.codemirror.replaceSelection(c.tpl);
+                        });
+                        tb.appendChild(btn);
+                    });
+                }, 50);
+            })();
+        </script>
+    @endif
+</x-dynamic-component>

--- a/resources/views/layouts/blog.blade.php
+++ b/resources/views/layouts/blog.blade.php
@@ -336,8 +336,8 @@
         .dark .docs-callout--danger { background-color: rgba(239,68,68,0.1); }
         .docs-callout--caution { border-color: #f59e0b; background-color: #fffbeb; }
         .dark .docs-callout--caution { background-color: rgba(245,158,11,0.1); }
-        .docs-callout__title { display: flex; align-items: center; gap: 0.5rem; font-weight: 600; font-size: 0.875rem; margin-bottom: 0.5rem; }
-        .docs-callout__icon { flex-shrink: 0; }
+        .docs-callout__title { display: flex; align-items: center; gap: 0.5rem; font-weight: 700; font-size: 1.125rem; margin-bottom: 0.5rem; }
+        .docs-callout__icon { flex-shrink: 0; width: 32px; height: 32px; }
         .docs-callout--tip .docs-callout__title { color: #065f46; }
         .dark .docs-callout--tip .docs-callout__title { color: #6ee7b7; }
         .docs-callout--info .docs-callout__title { color: #1e40af; }
@@ -346,6 +346,8 @@
         .dark .docs-callout--danger .docs-callout__title { color: #fca5a5; }
         .docs-callout--caution .docs-callout__title { color: #92400e; }
         .dark .docs-callout--caution .docs-callout__title { color: #fcd34d; }
+        .docs-callout__title--icon-only { margin-bottom: 0; }
+        .docs-callout__content { font-size: 0.75rem; }
         .docs-callout__content > :first-child { margin-top: 0; }
         .docs-callout__content > :last-child { margin-bottom: 0; }
     </style>

--- a/src/Filament/Components/CalloutMarkdownEditor.php
+++ b/src/Filament/Components/CalloutMarkdownEditor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Happytodev\Blogr\Filament\Components;
+
+use Filament\Forms\Components\MarkdownEditor;
+
+class CalloutMarkdownEditor extends MarkdownEditor
+{
+    /** @var view-string */
+    protected string $view = 'blogr::components.callout-markdown-editor';
+}

--- a/src/Filament/Livewire/AuthorBio.php
+++ b/src/Filament/Livewire/AuthorBio.php
@@ -3,11 +3,11 @@
 namespace Happytodev\Blogr\Filament\Livewire;
 
 use Filament\Actions\Action;
-use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Schema;
+use Happytodev\Blogr\Filament\Components\CalloutMarkdownEditor;
 use Happytodev\Blogr\Services\LocaleService;
 use Happytodev\Blogr\Services\Translation\TranslationProviderFactory;
 use Happytodev\Blogr\Services\TranslationUsageService;
@@ -51,7 +51,7 @@ class AuthorBio extends MyProfileComponent
             $tabs[] = Tabs\Tab::make($locale)
                 ->label("{$flag} {$label}")
                 ->schema([
-                    MarkdownEditor::make("bio.{$locale}")
+                    CalloutMarkdownEditor::make("bio.{$locale}")
                         ->label(__('blogr::blogr.profile.bio_label', ['locale' => $label]))
                         ->maxLength(2000)
                         ->nullable()

--- a/src/Filament/Pages/Auth/EditProfile.php
+++ b/src/Filament/Pages/Auth/EditProfile.php
@@ -5,10 +5,10 @@ namespace Happytodev\Blogr\Filament\Pages\Auth;
 use App\Models\User;
 use Filament\Auth\Pages\EditProfile as BaseEditProfile;
 use Filament\Forms\Components\FileUpload;
-use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
+use Happytodev\Blogr\Filament\Components\CalloutMarkdownEditor;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 
@@ -111,7 +111,7 @@ class EditProfile extends BaseEditProfile
         if ($localesEnabled && count($normalizedLocales) > 1) {
             // Multiple locales - create a markdown editor for each language
             foreach ($normalizedLocales as $locale => $label) {
-                $bioComponents[] = MarkdownEditor::make("bio.{$locale}")
+                $bioComponents[] = CalloutMarkdownEditor::make("bio.{$locale}")
                     ->label("Biography - {$label}")
                     ->maxLength(2000)
                     ->nullable()
@@ -130,7 +130,7 @@ class EditProfile extends BaseEditProfile
             }
         } else {
             // Single locale - just use 'en' as default
-            $bioComponents[] = MarkdownEditor::make('bio.en')
+            $bioComponents[] = CalloutMarkdownEditor::make('bio.en')
                 ->label('Biography')
                 ->maxLength(2000)
                 ->nullable()

--- a/src/Filament/Resources/BlogPostResource/Pages/ManageBlogPostTranslations.php
+++ b/src/Filament/Resources/BlogPostResource/Pages/ManageBlogPostTranslations.php
@@ -8,6 +8,7 @@ use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Happytodev\Blogr\Filament\Components\CalloutMarkdownEditor;
 use Happytodev\Blogr\Filament\Resources\BlogPostResource;
 use Happytodev\Blogr\Models\BlogPostTranslation;
 use Tables\Actions\CreateAction;
@@ -59,7 +60,7 @@ class ManageBlogPostTranslations extends ManageRelatedRecords
                     ->rows(3)
                     ->helperText('A brief summary of the post (optional)'),
 
-                Forms\Components\MarkdownEditor::make('content')
+                CalloutMarkdownEditor::make('content')
                     ->required()
                     ->columnSpanFull()
                     ->toolbarButtons([

--- a/src/Filament/Resources/BlogPostResource/RelationManagers/TranslationsRelationManager.php
+++ b/src/Filament/Resources/BlogPostResource/RelationManagers/TranslationsRelationManager.php
@@ -13,6 +13,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Happytodev\Blogr\Filament\Components\CalloutMarkdownEditor;
 use Happytodev\Blogr\Services\LocaleService;
 use Illuminate\Database\Eloquent\Model;
 
@@ -76,7 +77,7 @@ class TranslationsRelationManager extends RelationManager
                 })
                 ->columnSpan(2),
 
-            Forms\Components\MarkdownEditor::make('content')
+            CalloutMarkdownEditor::make('content')
                 ->label('Content')
                 ->required()
                 ->toolbarButtons([

--- a/src/Filament/Resources/BlogPosts/BlogPostForm.php
+++ b/src/Filament/Resources/BlogPosts/BlogPostForm.php
@@ -7,7 +7,6 @@ use Filament\Facades\Filament;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Hidden;
-use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -17,6 +16,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
+use Happytodev\Blogr\Filament\Components\CalloutMarkdownEditor;
 use Happytodev\Blogr\Models\BlogPost;
 use Happytodev\Blogr\Models\BlogSeries;
 use Happytodev\Blogr\Models\Category;
@@ -95,7 +95,7 @@ class BlogPostForm
                                     ->helperText('Short summary of the article (max 500 characters)')
                                     ->columnSpanFull(),
 
-                                MarkdownEditor::make('content')
+                                CalloutMarkdownEditor::make('content')
                                     ->label('Content')
                                     ->required()
                                     ->toolbarButtons([

--- a/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
+++ b/src/Filament/Resources/CmsPages/CmsBlockBuilder.php
@@ -8,7 +8,6 @@ use Filament\Forms\Components\Builder\Block;
 use Filament\Forms\Components\ColorPicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Hidden;
-use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -19,6 +18,7 @@ use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Tabs;
 use Happytodev\Blogr\Enums\CmsBlockType;
+use Happytodev\Blogr\Filament\Components\CalloutMarkdownEditor;
 use Happytodev\Blogr\Filament\Forms\LinkFieldsTrait;
 
 class CmsBlockBuilder
@@ -352,7 +352,7 @@ class CmsBlockBuilder
             ->schema(fn () => [
                 Section::make(__('Content'))
                     ->schema(fn () => [
-                        MarkdownEditor::make('content')
+                        CalloutMarkdownEditor::make('content')
                             ->label(__('Content'))
                             ->required()
                             ->toolbarButtons([
@@ -572,7 +572,7 @@ class CmsBlockBuilder
                                     ->maxLength(255)
                                     ->columnSpan(1),
 
-                                MarkdownEditor::make('bio')
+                                CalloutMarkdownEditor::make('bio')
                                     ->label(__('Bio'))
                                     ->toolbarButtons([
                                         'bold', 'italic', 'link', 'bulletList',
@@ -1556,7 +1556,7 @@ class CmsBlockBuilder
                             ->maxLength(255)
                             ->columnSpan(2),
 
-                        MarkdownEditor::make('bio')
+                        CalloutMarkdownEditor::make('bio')
                             ->label(__('Biography'))
                             ->toolbarButtons([
                                 'bold', 'italic', 'link', 'bulletList',

--- a/src/Rendering/Callout/CalloutRenderer.php
+++ b/src/Rendering/Callout/CalloutRenderer.php
@@ -20,16 +20,15 @@ class CalloutRenderer implements NodeRendererInterface
         $innerHtml = $childRenderer->renderNodes($node->children());
 
         $icon = match ($type) {
-            CalloutType::Tip => '<svg class="docs-callout__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>',
-            CalloutType::Info => '<svg class="docs-callout__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>',
-            CalloutType::Danger => '<svg class="docs-callout__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>',
-            CalloutType::Caution => '<svg class="docs-callout__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>',
+            CalloutType::Tip => '<svg class="docs-callout__icon" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.383a14.406 14.406 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"/></svg>',
+            CalloutType::Info => '<svg class="docs-callout__icon" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"/></svg>',
+            CalloutType::Caution => '<svg class="docs-callout__icon" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/></svg>',
+            CalloutType::Danger => '<svg class="docs-callout__icon" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 9l6 6m0-6l-6 6M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>',
         };
 
-        $titleHtml = '';
-        if ($title) {
-            $titleHtml = '<p class="docs-callout__title">'.$icon.' '.htmlspecialchars($title).'</p>';
-        }
+        $titleHtml = $title
+            ? '<p class="docs-callout__title">'.$icon.' '.htmlspecialchars($title).'</p>'
+            : '<p class="docs-callout__title docs-callout__title--icon-only">'.$icon.'</p>';
 
         $classes = 'docs-callout docs-callout--'.$type->value;
 

--- a/src/Rendering/Callout/CalloutStartParser.php
+++ b/src/Rendering/Callout/CalloutStartParser.php
@@ -22,6 +22,6 @@ class CalloutStartParser implements BlockStartParserInterface
 
         $cursor->advanceToEnd();
 
-        return BlockStart::of(new CalloutParser(new CalloutBlock($type, $title)));
+        return BlockStart::of(new CalloutParser(new CalloutBlock($type, $title)))->at($cursor);
     }
 }

--- a/tests/Feature/AuthorBioFieldEnhancementsTest.php
+++ b/tests/Feature/AuthorBioFieldEnhancementsTest.php
@@ -37,7 +37,7 @@ test('bio field uses MarkdownEditor component instead of Textarea', function () 
     $filePath = __DIR__.'/../../src/Filament/Pages/Auth/EditProfile.php';
     $content = file_get_contents($filePath);
 
-    expect($content)->toContain('MarkdownEditor::make')
+    expect($content)->toContain('CalloutMarkdownEditor::make')
         ->and($content)->not->toContain('Textarea::make("bio.');
 });
 
@@ -46,8 +46,8 @@ test('bio field with multilingual support uses MarkdownEditor for each locale', 
     $filePath = __DIR__.'/../../src/Filament/Pages/Auth/EditProfile.php';
     $content = file_get_contents($filePath);
 
-    expect($content)->toContain('MarkdownEditor::make("bio.')
-        ->and($content)->toContain('use Filament\Forms\Components\MarkdownEditor;');
+    expect($content)->toContain('CalloutMarkdownEditor::make("bio.')
+        ->and($content)->toContain('use Happytodev\Blogr\Filament\Components\CalloutMarkdownEditor;');
 });
 
 test('profile edit page has wider max-width on large screens', function () {

--- a/tests/Feature/CalloutMarkdownEditorTest.php
+++ b/tests/Feature/CalloutMarkdownEditorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Filament\Forms\Components\MarkdownEditor;
+use Happytodev\Blogr\Filament\Components\CalloutMarkdownEditor;
+use Happytodev\Blogr\Tests\TestCase;
+
+uses(TestCase::class);
+
+test('extends markdown editor', function () {
+    $field = CalloutMarkdownEditor::make('content');
+    expect($field)->toBeInstanceOf(MarkdownEditor::class);
+});
+
+test('uses custom view', function () {
+    $field = CalloutMarkdownEditor::make('content');
+    expect($field->getView())->toBe('blogr::components.callout-markdown-editor');
+});
+
+test('view contains all 4 callout buttons script', function () {
+    $path = __DIR__.'/../../resources/views/components/callout-markdown-editor.blade.php';
+    expect(file_exists($path))->toBeTrue();
+    $content = file_get_contents($path);
+    expect($content)
+        ->toContain('aria-label')
+        ->toContain('replaceSelection')
+        ->toContain(':::tip')
+        ->toContain(':::info')
+        ->toContain(':::caution')
+        ->toContain(':::danger')
+        ->toContain('callout-btn');
+});


### PR DESCRIPTION
## Summary
- New `CalloutMarkdownEditor` field with 4 toolbar buttons (Tip, Info, Caution, Danger)
- Callout icons always render (with or without title)
- Improved icon hierarchy: Caution → triangle, Danger → x-circle
- All icons upgraded to Heroicons v2 outline at 32px (crisper details)
- Title font-size 1.125rem, content font-size 0.75rem
- PDF exports now include callout CSS styling
- WCAG AA: aria-label, aria-haspopup, role, focus-visible on toolbar buttons

## CHANGELOG
### ✨ Features
- **callouts**: Icons now always render (with or without title)
- **callouts**: Improved icon hierarchy — caution uses triangle, danger uses x-circle
- **callouts**: Icons upgraded to Heroicons v2 outline at 32px
- **callouts**: Title 1.125rem, content 0.75rem
- **callouts**: CSS in PDF exports
- **editor**: CalloutMarkdownEditor with 4 toolbar buttons across all forms

### 🐛 Fixed
- **callouts**: CalloutStartParser now returns `->at($cursor)`

### 🧪 Tests
- CalloutMarkdownEditorTest, AuthorBioFieldEnhancementsTest updated, DocSettingsTest (PDF CSS)

## Test plan
- [x] `vendor/bin/pest --parallel` — 1401 passed (blogr core)
- [x] `vendor/bin/pest --parallel` — 62 passed (blogr-docs)