### PR TITLE
feat(nav): extend LinkTypeRegistry with plugin field factories and context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **nav**: Extend `LinkTypeRegistry` with context-aware resolvers and field factories — plugins can inject entity selector fields into the nav menu form and receive item data during URL resolution
+- **nav**: Render plugin-registered link type fields in top-level and sub-menu item forms; add `cms_page` support for sub-menu items
+- **nav**: Pass menu item context to plugin link type resolvers
+
+### 🐛 Fixed
+
+- **settings**: Invalidate opcache after saving config file — updated navigation menu items are visible immediately without requiring a hard refresh
+
 ## [v1.29.1](https://github.com/happytodev/blogr/compare/v1.29.0...v1.29.1) - 2026-07-07
 
 ### 🐛 Fixed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -39,7 +39,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''router'' on Illuminate\\Contracts\\Foundation\\Application\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 53
+			count: 54
 			path: src/BlogrServiceProvider.php
 
 		-
@@ -61,7 +61,7 @@ parameters:
 			path: src/BlogrServiceProvider.php
 
 		-
-			message: '#^Method Happytodev\\Blogr\\Contracts\\BlogrExtension@anonymous/BlogrServiceProvider\.php\:404\:\:getDependencies\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Happytodev\\Blogr\\Contracts\\BlogrExtension@anonymous/BlogrServiceProvider\.php\:417\:\:getDependencies\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/BlogrServiceProvider.php
@@ -659,6 +659,18 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: src/Events/UserDataExported.php
+
+		-
+			message: '#^Property Happytodev\\Blogr\\Filament\\Components\\CalloutMarkdownEditor\:\:\$view \(view\-string\) does not accept default value of type string\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: src/Filament/Components/CalloutMarkdownEditor.php
+
+		-
+			message: '#^Method Happytodev\\Blogr\\Filament\\Components\\IconPicker\:\:getIconsWithSvg\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Filament/Components/IconPicker.php
 
 		-
 			message: '#^Access to an undefined property Happytodev\\Blogr\\Filament\\Livewire\\AuthorBio\:\:\$form\.$#'
@@ -4591,6 +4603,24 @@ parameters:
 			path: src/Helpers/ConfigHelper.php
 
 		-
+			message: '#^Method Happytodev\\Blogr\\Helpers\\IconHelper\:\:getSvg\(\) should return string\|null but returns string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Helpers/IconHelper.php
+
+		-
+			message: '#^Method Happytodev\\Blogr\\Helpers\\IconHelper\:\:outlineIcons\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Helpers/IconHelper.php
+
+		-
+			message: '#^Property Happytodev\\Blogr\\Helpers\\IconHelper\:\:\$outlineIcons type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Helpers/IconHelper.php
+
+		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$locale\.$#'
 			identifier: property.notFound
 			count: 4
@@ -7061,6 +7091,12 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: src/Policies/UserPolicy.php
+
+		-
+			message: '#^Property Happytodev\\Blogr\\Rendering\\Callout\\CalloutParser\:\:\$ended is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Rendering/Callout/CalloutParser.php
 
 		-
 			message: '#^Cannot access offset ''name'' on mixed\.$#'

--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -78,7 +78,7 @@
             }
             
             // Fallback to plugin-registered link types
-            if ($url === '#' && ($pluginUrl = app(\Happytodev\Blogr\Services\LinkTypeRegistry::class)->resolve($item['type'] ?? ''))) {
+            if ($url === '#' && ($pluginUrl = app(\Happytodev\Blogr\Services\LinkTypeRegistry::class)->resolve($item['type'] ?? '', $item))) {
                 $url = $pluginUrl;
             }
             

--- a/src/Filament/Pages/BlogrSettings.php
+++ b/src/Filament/Pages/BlogrSettings.php
@@ -3575,6 +3575,13 @@ class BlogrSettings extends Page
         // Write to file
         File::put($configPath, $content);
 
+        // Invalidate opcache so subsequent requests read the updated file
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($configPath, true);
+        } elseif (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
+
         // Also update in-memory config so current request sees the new values
         config()->set('blogr', $updatedConfig);
     }

--- a/src/Filament/Pages/BlogrSettings.php
+++ b/src/Filament/Pages/BlogrSettings.php
@@ -2193,6 +2193,12 @@ class BlogrSettings extends Page
                                                 ->required(fn (Get $get) => $get('type') === 'cms_page')
                                                 ->columnSpan(1),
 
+                                            // Plugin-registered link type fields
+                                            ...collect(app(LinkTypeRegistry::class)->getFieldFactories())
+                                                ->map(fn ($factory) => $factory())
+                                                ->values()
+                                                ->all(),
+
                                             Select::make('target')
                                                 ->label('Open in')
                                                 ->options([
@@ -2241,13 +2247,24 @@ class BlogrSettings extends Page
 
                                                     Select::make('type')
                                                         ->label('Link Type')
-                                                        ->options([
-                                                            'external' => 'External URL',
-                                                            'blog' => 'Blog Home',
-                                                            'category' => 'Category',
-                                                        ])
+                                                        ->options(function () {
+                                                            $options = [
+                                                                'external' => 'External URL',
+                                                                'blog' => 'Blog Home',
+                                                                'category' => 'Category',
+                                                                'cms_page' => 'CMS Page',
+                                                            ];
+
+                                                            $pluginOptions = app(LinkTypeRegistry::class)->getOptions();
+
+                                                            if (! empty($pluginOptions)) {
+                                                                $options['Plugins'] = $pluginOptions;
+                                                            }
+
+                                                            return $options;
+                                                        })
                                                         ->default('external')
-                                                        ->stateBindingModifiers(['defer'])
+                                                        ->live()
                                                         ->required()
                                                         ->columnSpan(1),
 
@@ -2274,6 +2291,28 @@ class BlogrSettings extends Page
                                                         ->visible(fn (Get $get) => $get('type') === 'category')
                                                         ->required(fn (Get $get) => $get('type') === 'category')
                                                         ->columnSpan(1),
+
+                                                    Select::make('cms_page_id')
+                                                        ->label('Select CMS Page')
+                                                        ->options(function () {
+                                                            return CmsPage::with('translations')
+                                                                ->get()
+                                                                ->mapWithKeys(function ($page) {
+                                                                    $translation = $page->translations->first();
+
+                                                                    return [$page->id => $translation->title ?? 'Page #'.$page->id];
+                                                                });
+                                                        })
+                                                        ->searchable()
+                                                        ->visible(fn (Get $get) => $get('type') === 'cms_page')
+                                                        ->required(fn (Get $get) => $get('type') === 'cms_page')
+                                                        ->columnSpan(1),
+
+                                                    // Plugin-registered link type fields for sub-menu items
+                                                    ...collect(app(LinkTypeRegistry::class)->getFieldFactories())
+                                                        ->map(fn ($factory) => $factory())
+                                                        ->values()
+                                                        ->all(),
 
                                                     Select::make('target')
                                                         ->label('Open in')

--- a/src/Services/LinkTypeRegistry.php
+++ b/src/Services/LinkTypeRegistry.php
@@ -6,12 +6,12 @@ use Closure;
 
 class LinkTypeRegistry
 {
-    /** @var array<string, array{label: string, resolver: Closure}> */
+    /** @var array<string, array{label: string, resolver: Closure, fieldFactory: ?Closure}> */
     protected array $types = [];
 
-    public function register(string $key, string $label, Closure $resolver): void
+    public function register(string $key, string $label, Closure $resolver, ?Closure $fieldFactory = null): void
     {
-        $this->types[$key] = compact('label', 'resolver');
+        $this->types[$key] = compact('label', 'resolver', 'fieldFactory');
     }
 
     public function getOptions(): array
@@ -19,17 +19,33 @@ class LinkTypeRegistry
         return array_map(fn (array $type): string => $type['label'], $this->types);
     }
 
-    public function resolve(string $key): ?string
+    public function resolve(string $key, mixed $context = null): ?string
     {
         if (! isset($this->types[$key])) {
             return null;
         }
 
-        return ($this->types[$key]['resolver'])();
+        return ($this->types[$key]['resolver'])($context);
     }
 
     public function has(string $key): bool
     {
         return isset($this->types[$key]);
+    }
+
+    /** @return array<string, Closure> */
+    public function getFieldFactories(): array
+    {
+        return array_reduce(
+            array_keys($this->types),
+            function (array $carry, string $key): array {
+                if ($this->types[$key]['fieldFactory'] !== null) {
+                    $carry[$key] = $this->types[$key]['fieldFactory'];
+                }
+
+                return $carry;
+            },
+            []
+        );
     }
 }


### PR DESCRIPTION
## Summary

Extend the plugin link type system so extensions can inject entity selector fields into the navigation menu item form and receive menu item context during URL resolution.

Also fixes a config caching issue where updated menu items were not visible immediately after saving settings.

## Commits

1. `feat(nav): extend LinkTypeRegistry with field factories and context`
2. `feat(nav): render plugin link type fields in nav form and pass context`
   - Top-level and sub-menu item forms now render plugin field factories
   - Sub-menu items now support `cms_page` type
3. `fix(settings): invalidate opcache after config file write`
4. `docs(changelog): document plugin link type fields and opcache fix`

## CHANGELOG

### Added
- Extend LinkTypeRegistry with context-aware resolvers and field factories
- Render plugin-registered link type fields in top-level and sub-menu item forms
- Add cms_page support for sub-menu items
- Pass menu item context to plugin link type resolvers

### Fixed
- Invalidate opcache after saving config file

## Test plan
- [ ] `vendor/bin/pest --parallel`