### PR TITLE
feat(markdown): add image lightbox for markdown images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **markdown**: Images in Markdown content are now wrapped in a lightbox trigger — clicking opens a full-screen Alpine.js overlay with caption support (#312)
+- **markdown**: New `ImageLightboxRenderer` CommonMark renderer for blog posts, CMS pages, content blocks, and author bios
+- **ui**: New `<x-blogr::image-lightbox />` Alpine.js component with close-on-escape, close-on-backdrop-click, and body scroll lock
+
 ## [v1.31.0](https://github.com/happytodev/blogr/compare/v1.30.0...v1.31.0) - 2026-07-07
 
 ### ✨ Features

--- a/resources/views/components/image-lightbox.blade.php
+++ b/resources/views/components/image-lightbox.blade.php
@@ -1,0 +1,42 @@
+<div
+    x-data="{
+        open: false,
+        src: '',
+        caption: '',
+        init() {
+            var self = this;
+            document.addEventListener('click', function (e) {
+                var trigger = e.target.closest('.blogr-lightbox-trigger');
+                if (trigger) {
+                    e.preventDefault();
+                    self.src = trigger.href;
+                    self.caption = trigger.dataset.caption || '';
+                    self.open = true;
+                    document.body.style.overflow = 'hidden';
+                }
+            });
+        },
+        close() {
+            this.open = false;
+            document.body.style.overflow = '';
+        }
+    }"
+    x-show="open"
+    x-cloak
+    @keydown.window.escape="close"
+    @click.self="close"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-4"
+    role="dialog"
+    aria-modal="true"
+    :aria-label="caption || 'Image'"
+>
+    <figure class="relative max-w-[90vw] max-h-[90vh] flex flex-col items-center">
+        <img :src="src" :alt="caption" class="max-w-full max-h-[85vh] w-auto h-auto object-contain rounded-lg shadow-2xl">
+        <figcaption x-show="caption" x-text="caption" class="mt-3 text-sm text-white/80 text-center max-w-lg"></figcaption>
+        <button @click="close" class="absolute -top-3 -right-3 w-8 h-8 flex items-center justify-center rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50" aria-label="Close">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+        </button>
+    </figure>
+</div>

--- a/resources/views/layouts/blog.blade.php
+++ b/resources/views/layouts/blog.blade.php
@@ -402,6 +402,9 @@
     <!-- DEBUG: BEFORE INCLUDE -->
     @include('blogr::components.back-to-top')
 
+    {{-- Image Lightbox --}}
+    <x-blogr::image-lightbox />
+
     <script>
         (function() {
             function addCopyButtons() {

--- a/src/Helpers/MarkdownHelper.php
+++ b/src/Helpers/MarkdownHelper.php
@@ -3,11 +3,13 @@
 namespace Happytodev\Blogr\Helpers;
 
 use Happytodev\Blogr\Extensions\VideoEmbedAdapter;
+use Happytodev\Blogr\Rendering\ImageLightboxRenderer;
 use Happytodev\Blogr\Rendering\ShikiCodeBlockRenderer;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
 use League\CommonMark\Extension\Embed\EmbedExtension;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
@@ -44,6 +46,8 @@ class MarkdownHelper
                 IndentedCode::class,
                 new ShikiCodeBlockRenderer,
             );
+
+            $environment->addRenderer(Image::class, new ImageLightboxRenderer);
 
             static::$converter = new MarkdownConverter($environment);
         }

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -13,6 +13,7 @@ use Happytodev\Blogr\Models\CategoryTranslation;
 use Happytodev\Blogr\Models\Tag;
 use Happytodev\Blogr\Models\TagTranslation;
 use Happytodev\Blogr\Rendering\Callout\CalloutExtension;
+use Happytodev\Blogr\Rendering\ImageLightboxRenderer;
 use Happytodev\Blogr\Rendering\ShikiCodeBlockRenderer;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\View;
@@ -21,6 +22,7 @@ use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
 use League\CommonMark\Extension\Embed\EmbedExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use League\CommonMark\Extension\Table\TableExtension;
@@ -292,6 +294,7 @@ class BlogController
 
         $environment->addRenderer(FencedCode::class, new ShikiCodeBlockRenderer);
         $environment->addRenderer(IndentedCode::class, new ShikiCodeBlockRenderer);
+        $environment->addRenderer(Image::class, new ImageLightboxRenderer);
 
         $converter = new MarkdownConverter($environment);
 

--- a/src/Rendering/ImageLightboxRenderer.php
+++ b/src/Rendering/ImageLightboxRenderer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Happytodev\Blogr\Rendering;
+
+use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
+use League\CommonMark\Xml\XmlNodeRendererInterface;
+
+class ImageLightboxRenderer implements NodeRendererInterface, XmlNodeRendererInterface
+{
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
+    {
+        if (! $node instanceof Image) {
+            throw new \InvalidArgumentException('Expected Image node, got '.get_class($node));
+        }
+
+        $url = $node->getUrl();
+        $alt = $childRenderer->renderNodes($node->children());
+        $title = $node->getTitle() ?? '';
+
+        $imgAttrs = ['src' => $url, 'alt' => $alt];
+        if ($title !== '') {
+            $imgAttrs['title'] = $title;
+        }
+
+        $img = new HtmlElement('img', $imgAttrs, null, true);
+
+        $parent = $node->parent();
+        if ($parent instanceof Link) {
+            return (string) $img;
+        }
+
+        $caption = $title !== '' ? $title : $alt;
+
+        return (string) new HtmlElement('a', [
+            'href' => $url,
+            'class' => 'blogr-lightbox-trigger',
+            'data-caption' => $caption,
+        ], $img);
+    }
+
+    public function getXmlTagName(Node $node): string
+    {
+        return 'image_lightbox';
+    }
+
+    public function getXmlAttributes(Node $node): array
+    {
+        return [];
+    }
+}

--- a/tests/Feature/FeatureImageLightboxInMarkdownTest.php
+++ b/tests/Feature/FeatureImageLightboxInMarkdownTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Happytodev\Blogr\Tests\TestCase;
+
+uses(TestCase::class);
+
+use Happytodev\Blogr\Helpers\MarkdownHelper;
+
+test('markdown image is wrapped in lightbox trigger anchor', function () {
+    $html = MarkdownHelper::toHtml('![My Alt](https://example.com/image.jpg)');
+
+    expect($html)
+        ->toContain('<a href="https://example.com/image.jpg" class="blogr-lightbox-trigger"')
+        ->and($html)->toContain('<img src="https://example.com/image.jpg" alt="My Alt"');
+});
+
+test('markdown image with title sets data-caption attribute', function () {
+    $html = MarkdownHelper::toHtml('![My Alt](https://example.com/image.jpg "Photo caption")');
+
+    expect($html)
+        ->toContain('data-caption="Photo caption"');
+});
+
+test('markdown image inside a link is not wrapped in lightbox trigger', function () {
+    $html = MarkdownHelper::toHtml('[![Clickable](https://example.com/img.jpg)](https://example.com/page)');
+
+    // The image should not have the lightbox trigger class on its parent
+    expect($html)->not->toContain('blogr-lightbox-trigger');
+
+    // The image should be directly inside an anchor pointing to the link URL
+    expect($html)->toMatch('/<a href="https:\\/\\/example\\.com\\/page">\\s*<img src="https:\\/\\/example\\.com\\/img\\.jpg" alt="Clickable" \\/>\\s*<\\/a>/');
+});
+
+test('markdown without images is not affected', function () {
+    $html = MarkdownHelper::toHtml('# Just a heading');
+
+    expect($html)->toContain('<h1>Just a heading</h1>')
+        ->and($html)->not->toContain('blogr-lightbox-trigger');
+});
+
+test('multiple images in markdown all get lightbox wrappers', function () {
+    $md = <<<'MD'
+First image: ![One](https://example.com/1.jpg)
+
+Second image: ![Two](https://example.com/2.jpg)
+MD;
+
+    $html = MarkdownHelper::toHtml($md);
+
+    expect($html)
+        ->toContain('<a href="https://example.com/1.jpg" class="blogr-lightbox-trigger"')
+        ->and($html)->toContain('<a href="https://example.com/2.jpg" class="blogr-lightbox-trigger"');
+});


### PR DESCRIPTION
## Summary
- Add `ImageLightboxRenderer` CommonMark renderer that wraps images in `<a class="blogr-lightbox-trigger">` with caption support
- Add Alpine.js `<x-blogr::image-lightbox />` component with full-screen overlay
- Register renderer in `MarkdownHelper` (CMS, blocks, bios) and `BlogController` (blog posts)
- Images inside markdown links are excluded from lightbox wrapping

## CHANGELOG
- **markdown**: Images in Markdown content now wrapped in a lightbox trigger - full-screen Alpine.js overlay with caption support (#312)
- **markdown**: New `ImageLightboxRenderer` CommonMark renderer for blog posts, CMS pages, content blocks, and author bios
- **ui**: New `<x-blogr::image-lightbox />` Alpine.js component

## Test plan
- [x] `vendor/bin/pest --parallel` — 1409 passed
- [x] `vendor/bin/pest --filter "FeatureImageLightboxInMarkdown"` — 5 passed
- [x] Anti-false-positive gate confirmed