### PR TITLE
docs: add issue auto-close convention using Closes #N in PR body

### DIFF
--- a/.opencode/skills/git-changelog-workflow/SKILL.md
+++ b/.opencode/skills/git-changelog-workflow/SKILL.md
@@ -249,6 +249,7 @@ gh pr create --title "type(scope): short title" --body "$(cat <<'EOF'
 - [ ] vendor/bin/pest --parallel
 - [ ] …
 
+Closes #<issue_number>
 EOF
 )" --base main
 ```
@@ -258,6 +259,8 @@ Otherwise, provide the compare URL:
 `https://github.com/happytodev/blogr/compare/main...BRANCH`
 
 ### Suggested PR body
+
+The PR body MUST include `Closes #<issue_number>` to auto-close the related issue on merge.
 
 ```markdown
 ## Summary
@@ -269,6 +272,8 @@ Otherwise, provide the compare URL:
 ## Test plan
 - [ ] `vendor/bin/pest --parallel`
 - [ ] …
+
+Closes #<issue_number>
 ```
 
 Return the URL of the created PR or the "New Pull Request" link.

--- a/.opencode/skills/issue-to-mr/SKILL.md
+++ b/.opencode/skills/issue-to-mr/SKILL.md
@@ -199,11 +199,13 @@ This skill handles:
 
 ## Step 9 — Close the issue
 
-After the PR is merged, close the issue with a reference:
+The issue is auto-closed on merge via `Closes #<issue_number>` in the PR
+description (see git-changelog-workflow Step 5). No manual close is needed.
+
+If the PR was created without `Closes #<issue_number>`, close manually:
 
 ```bash
-gh issue comment $ISSUE_ID --body "Fixed in PR #$PR_NUMBER ($HASH)"
-gh issue close $ISSUE_ID
+gh issue close $ISSUE_ID --comment "Fixed in $HASH"
 ```
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ issue before any code is written or proposed.** This ensures traceability.
 - The issue is created via `gh issue create` immediately upon understanding
   the need
 - The issue number is referenced in all subsequent commits and PRs
-- The issue is closed when the work is merged into `main`
+- The issue is closed when the work is merged into `main` — the PR description MUST include `Closes #<issue_number>` to auto-close on merge
 - Skipping this is a process error
 
 ## ⚠️ Commit policy — ZERO TOLERANCE
@@ -63,6 +63,7 @@ FilamentPHP v4 plugin package (`happytodev/blogr`) — a multilingual blog syste
 | File | Content |
 |------|---------|
 | [README.md](README.md) | Installation, prerequisites, basic commands |
+| [docs/RELEASE_NOTES.md](docs/RELEASE_NOTES.md) | Version compatibility, support policy, per-major feature documentation |
 | [docs/](docs/) | Feature documentation (CMS, gradients, translations, RGPD, etc.) |
 | [artist-portfolio-audit](.opencode/skills/artist-portfolio-audit/SKILL.md) | Variance analysis for the illustrator’s portfolio website |
 


### PR DESCRIPTION
## Summary

Updates the project conventions so that issues are auto-closed on merge via `Closes #<issue_number>` in the PR description, instead of requiring manual closure.

## Changes

- **AGENTS.md**: Update issue closure rule to mandate `Closes #<issue_number>` in PR description
- **git-changelog-workflow**: Add `Closes #<issue_number>` to PR body templates
- **issue-to-mr**: Replace manual close workflow with auto-close via PR description