### PR TITLE
fix(icons): resolve heroicons SVG path via base_path for production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ issue before any code is written or proposed.** This ensures traceability.
 - User says "I need a feature" → create issue with `--label feature`
 - The issue is created via `gh issue create` immediately upon understanding
   the need
+- **All issues MUST be written in English** (title + body)
 - The issue number is referenced in all subsequent commits and PRs
 - The issue is closed when the work is merged into `main` — the PR description MUST include `Closes #<issue_number>` to auto-close on merge
 - Skipping this is a process error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `blogr` will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **icons**: Fix icon picker search returning no results in production by resolving blade-heroicons SVGs via `base_path()` instead of the package-relative vendor path (#319)
+
+### 🔄 Changed
+
+- **docs**: Add requirement that all GitHub issues must be written in English (AGENTS.md)
+
 ## [v2.0.0](https://github.com/happytodev/blogr/compare/v1.32.0...v2.0.0) - 2026-07-07
 
 ### ⬆️ Dependencies

--- a/src/Helpers/IconHelper.php
+++ b/src/Helpers/IconHelper.php
@@ -16,7 +16,7 @@ class IconHelper
         }
 
         return static::$outlineIcons = Cache::rememberForever('blogr-heroicon-outline-list', function () {
-            $svgDir = dirname(__DIR__, 2).'/vendor/blade-ui-kit/blade-heroicons/resources/svg';
+            $svgDir = static::resolveSvgDirectory();
 
             if (! is_dir($svgDir)) {
                 return [];
@@ -39,9 +39,25 @@ class IconHelper
         });
     }
 
+    public static function resolveSvgDirectory(): string
+    {
+        $paths = [
+            base_path('vendor/blade-ui-kit/blade-heroicons/resources/svg'),
+            dirname(__DIR__, 2).'/vendor/blade-ui-kit/blade-heroicons/resources/svg',
+        ];
+
+        foreach ($paths as $path) {
+            if (is_dir($path)) {
+                return $path;
+            }
+        }
+
+        return $paths[0];
+    }
+
     public static function getSvg(string $icon): ?string
     {
-        $path = dirname(__DIR__, 2)."/vendor/blade-ui-kit/blade-heroicons/resources/svg/o-{$icon}.svg";
+        $path = static::resolveSvgDirectory()."/o-{$icon}.svg";
 
         if (! file_exists($path)) {
             return null;

--- a/tests/Unit/regression_319_icon_picker_empty_in_production.php
+++ b/tests/Unit/regression_319_icon_picker_empty_in_production.php
@@ -1,0 +1,34 @@
+<?php
+
+use Happytodev\Blogr\Helpers\IconHelper;
+
+beforeEach(function () {
+    IconHelper::flushCache();
+});
+
+it('resolves the icon directory via base_path first (production path)', function () {
+    $directory = IconHelper::resolveSvgDirectory();
+
+    expect($directory)->toStartWith(base_path())
+        ->and(is_dir($directory))->toBeTrue();
+});
+
+it('finds heroicons when using base_path (production path)', function () {
+    $icons = IconHelper::outlineIcons();
+
+    expect($icons)->not->toBeEmpty()
+        ->and($icons)->toHaveKey('academic-cap');
+});
+
+it('can retrieve SVG content for a known icon', function () {
+    $svg = IconHelper::getSvg('academic-cap');
+
+    expect($svg)->not->toBeNull()
+        ->and($svg)->toContain('<svg');
+});
+
+it('returns null for an unknown icon', function () {
+    $svg = IconHelper::getSvg('nonexistent-icon');
+
+    expect($svg)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Fix icon picker search showing no results in production by resolving blade-heroicons SVGs via `base_path()` instead of the package-relative vendor path
- Add `resolveSvgDirectory()` method with fallback: `base_path()` first (production), `dirname(__DIR__, 2).'/vendor/...'` second (development)
- Regression test validates path resolution and outline icon discovery
- Add English-only requirement for GitHub issues to AGENTS.md

## CHANGELOG

- **🐛 Bug Fixes**: `fix(icons): resolve heroicons SVG path via base_path for production` (#319)
- **🔄 Changed**: `docs(agents): enforce English-only rule for GitHub issues`

## Test plan

- [x] `vendor/bin/pest --parallel` — 1409 passed, 0 regressions
- [x] Regression test covers: path resolution via `base_path()`, outlineIcons() non-empty, getSvg() for known icon, null for unknown icon
- [x] Anti-false-positive gate passed: removing `base_path()` causes the path resolution test to fail

Closes #319